### PR TITLE
Increase unit test coverage across all modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     </properties>
 
     <scm>
@@ -184,6 +185,32 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <propertyName>surefireArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
 
         <extensions>
             <extension>

--- a/pom.xml
+++ b/pom.xml
@@ -220,4 +220,49 @@
             </extension>
         </extensions>
     </build>
+
+    <profiles>
+        <!-- Referenced by the Jenkins pipeline (`mvn clean install -Pcode-coverage-validation`); previously
+             did not exist, so CI silently ran with no coverage gate at all. -->
+        <profile>
+            <id>code-coverage-validation</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>check</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <rule>
+                                            <element>BUNDLE</element>
+                                            <limits>
+                                                <limit>
+                                                    <counter>INSTRUCTION</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>0.75</minimum>
+                                                </limit>
+                                                <limit>
+                                                    <counter>BRANCH</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>0.60</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/reportium-import-java/src/test/java/com/perfecto/reportium/imports/client/ReportiumImportClientTest.java
+++ b/reportium-import-java/src/test/java/com/perfecto/reportium/imports/client/ReportiumImportClientTest.java
@@ -3,10 +3,12 @@ package com.perfecto.reportium.imports.client;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.perfecto.reportium.exception.ReportiumException;
 import com.perfecto.reportium.imports.client.connection.Connection;
 import com.perfecto.reportium.imports.client.connection.HttpResponse;
 import com.perfecto.reportium.imports.client.connection.ReportingHttpClient;
 import com.perfecto.reportium.imports.model.ImportExecutionContext;
+import com.perfecto.reportium.imports.model.attachment.Attachment;
 import com.perfecto.reportium.imports.model.attachment.ArtifactData;
 import com.perfecto.reportium.imports.model.attachment.ScreenshotAttachment;
 import com.perfecto.reportium.imports.model.attachment.TextAttachment;
@@ -14,10 +16,12 @@ import com.perfecto.reportium.imports.model.command.Command;
 import com.perfecto.reportium.imports.model.command.CommandParameter;
 import com.perfecto.reportium.imports.model.command.CommandStatus;
 import com.perfecto.reportium.imports.model.command.CommandType;
+import com.perfecto.reportium.imports.model.event.AddArtifactsEvent;
 import com.perfecto.reportium.imports.model.event.CommandEvent;
 import com.perfecto.reportium.imports.model.event.TestEndEvent;
 import com.perfecto.reportium.imports.model.event.TestExecutionStatus;
 import com.perfecto.reportium.imports.model.event.TestStartEvent;
+import com.perfecto.reportium.model.CustomField;
 import com.perfecto.reportium.test.TestContext;
 import com.perfecto.reportium.test.result.TestResultFactory;
 import org.apache.commons.io.IOUtils;
@@ -43,6 +47,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -325,6 +331,478 @@ public class ReportiumImportClientTest {
         Files.delete(tempFile);
     }
 
+
+    @Test
+    public void stepStart() throws IOException {
+        String description = "my step";
+
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> httpEntityCapture = mockPost();
+
+        mocksControl.replay();
+        tested.stepStart(description);
+        mocksControl.verify();
+
+        String json = IOUtils.toString(httpEntityCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        com.perfecto.reportium.imports.model.event.StepStartEvent stepStartEvent = gson.fromJson(json, com.perfecto.reportium.imports.model.event.StepStartEvent.class);
+        assertEquals(stepStartEvent.getExternalId(), externalId);
+        assertEquals(stepStartEvent.getDescription(), description);
+    }
+
+    @Test
+    public void stepEnd_noMessage() throws IOException {
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> httpEntityCapture = mockPost();
+
+        mocksControl.replay();
+        tested.stepEnd();
+        mocksControl.verify();
+
+        String json = IOUtils.toString(httpEntityCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        com.perfecto.reportium.imports.model.event.StepEndEvent stepEndEvent = gson.fromJson(json, com.perfecto.reportium.imports.model.event.StepEndEvent.class);
+        assertEquals(stepEndEvent.getExternalId(), externalId);
+        assertNull(stepEndEvent.getMessage());
+    }
+
+    @Test
+    public void stepEnd_withMessage() throws IOException {
+        String message = "step done";
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> httpEntityCapture = mockPost();
+
+        mocksControl.replay();
+        tested.stepEnd(message);
+        mocksControl.verify();
+
+        String json = IOUtils.toString(httpEntityCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        com.perfecto.reportium.imports.model.event.StepEndEvent stepEndEvent = gson.fromJson(json, com.perfecto.reportium.imports.model.event.StepEndEvent.class);
+        assertEquals(stepEndEvent.getMessage(), message);
+    }
+
+    @Test
+    public void addArtifacts_nullVarargs_noOp() {
+        mocksControl.replay();
+        tested.addArtifacts((Attachment[]) null);
+        mocksControl.verify();
+    }
+
+    @Test
+    public void addArtifacts_nullCollection_noOp() {
+        mocksControl.replay();
+        tested.addArtifacts((Collection<Attachment>) null);
+        mocksControl.verify();
+    }
+
+    @Test
+    public void addArtifacts_emptyCollection_noOp() {
+        mocksControl.replay();
+        tested.addArtifacts(Collections.<Attachment>emptyList());
+        mocksControl.verify();
+    }
+
+    @Test
+    public void addArtifacts_withAttachment_success() throws IOException {
+        Path tempFile = Files.createTempFile("temp_", ".txt");
+        String uploadUrl = "https://some.s3.address.com/bucket-name/artifact/tenant/externalId/filename.png?someParam1=someParamValue1";
+        TextAttachment textAttachment = new TextAttachment.Builder().withAbsolutePath(tempFile.toString()).build();
+
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> postCapture = mockPost();
+        mockGet(uploadUrl);
+
+        Capture<URI> putUriCapture = EasyMock.newCapture();
+        Capture<Header> headerCapture = EasyMock.newCapture();
+        expect(reportingHttpClientMock.put(capture(putUriCapture), anyObject(HttpEntity.class), anyObject(Map.class), capture(headerCapture)))
+                .andReturn(getHttpResponse(200, null));
+
+        mocksControl.replay();
+        tested.addArtifacts(textAttachment);
+        mocksControl.verify();
+
+        String json = IOUtils.toString(postCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        AddArtifactsEvent event = gson.fromJson(json, AddArtifactsEvent.class);
+        assertEquals(event.getArtifacts().size(), 1);
+
+        Files.delete(tempFile);
+    }
+
+    @Test
+    public void addArtifacts_uploadFailure_failOnUploadFailureFalse_eventSentWithoutArtifact() throws IOException {
+        Path tempFile = Files.createTempFile("temp_", ".txt");
+        TextAttachment attachment = new TextAttachment.Builder().withAbsolutePath(tempFile.toString()).build();
+        Files.delete(tempFile);
+
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> postCapture = mockPost();
+
+        mocksControl.replay();
+        tested.addArtifacts(attachment);
+        mocksControl.verify();
+
+        String json = IOUtils.toString(postCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        AddArtifactsEvent event = gson.fromJson(json, AddArtifactsEvent.class);
+        assertEquals(event.getArtifacts().size(), 0);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void addArtifacts_uploadFailure_failOnUploadFailureTrue_throws() throws IOException {
+        Path tempFile = Files.createTempFile("temp_", ".txt");
+        TextAttachment attachment = new TextAttachment.Builder().withAbsolutePath(tempFile.toString()).build();
+        Files.delete(tempFile);
+        tested.setFailOnUploadFailure(true);
+
+        mocksControl.replay();
+        tested.addArtifacts(attachment);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void command_withScreenshotUploadFailure_failOnUploadFailureTrue_throws() throws IOException {
+        Path tempFile = Files.createTempFile("temp_", ".png");
+        ScreenshotAttachment screenshot = new ScreenshotAttachment.Builder().withAbsolutePath(tempFile.toString()).build();
+        Files.delete(tempFile);
+        tested.setFailOnUploadFailure(true);
+
+        Command command = new Command.Builder().withName("cmd").withScreenshotAttachments(screenshot).build();
+
+        mocksControl.replay();
+        tested.command(command);
+    }
+
+    @Test
+    public void command_withScreenshotUploadFailure_failOnUploadFailureFalse_continuesWithoutScreenshot() throws IOException {
+        Path tempFile = Files.createTempFile("temp_", ".png");
+        ScreenshotAttachment screenshot = new ScreenshotAttachment.Builder().withAbsolutePath(tempFile.toString()).build();
+        Files.delete(tempFile);
+
+        Command command = new Command.Builder().withName("cmd").withScreenshotAttachments(screenshot).build();
+
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> postCapture = mockPost();
+
+        mocksControl.replay();
+        tested.command(command);
+        mocksControl.verify();
+
+        String json = IOUtils.toString(postCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        CommandEvent commandEvent = gson.fromJson(json, CommandEvent.class);
+        assertEquals(commandEvent.getCommand().getScreenshots().size(), 0);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testStop_withTextAttachmentUploadFailure_failOnUploadFailureTrue_throws() throws IOException {
+        Path tempFile = Files.createTempFile("temp_", ".txt");
+        TextAttachment attachment = new TextAttachment.Builder().withAbsolutePath(tempFile.toString()).build();
+        Files.delete(tempFile);
+        tested.setFailOnUploadFailure(true);
+
+        mocksControl.replay();
+        tested.testStop(TestResultFactory.createSuccess(), attachment);
+    }
+
+    @Test
+    public void testStop_nullTextAttachmentsVarargs_delegatesToSingleArgOverload() throws IOException {
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        mockPost();
+
+        mocksControl.replay();
+        tested.testStop(TestResultFactory.createSuccess(), (TextAttachment[]) null);
+        mocksControl.verify();
+    }
+
+    @Test
+    public void testStop_withTestContextOverload() throws IOException {
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> postCapture = mockPost();
+        TestContext testContext = new TestContext.Builder().withTestExecutionTags("tag1").build();
+
+        mocksControl.replay();
+        tested.testStop(TestResultFactory.createSuccess(), testContext);
+        mocksControl.verify();
+
+        String json = IOUtils.toString(postCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        TestEndEvent testEndEvent = gson.fromJson(json, TestEndEvent.class);
+        assertTrue(testEndEvent.getTags().contains("tag1"));
+    }
+
+    @Test
+    public void testStop_withNullTestContext_threeArgOverload() throws IOException {
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        mockPost();
+
+        mocksControl.replay();
+        tested.testStop(TestResultFactory.createSuccess(), Collections.<TextAttachment>emptyList(), null);
+        mocksControl.verify();
+    }
+
+    @Test
+    public void testStop_withTextAttachmentUploadFailure_failOnUploadFailureFalse_eventSentWithoutArtifact() throws IOException {
+        Path tempFile = Files.createTempFile("temp_", ".txt");
+        TextAttachment attachment = new TextAttachment.Builder().withAbsolutePath(tempFile.toString()).build();
+        Files.delete(tempFile);
+
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> postCapture = mockPost();
+
+        mocksControl.replay();
+        tested.testStop(TestResultFactory.createSuccess(), attachment);
+        mocksControl.verify();
+
+        String json = IOUtils.toString(postCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        TestEndEvent testEndEvent = gson.fromJson(json, TestEndEvent.class);
+        assertEquals(testEndEvent.getArtifacts().size(), 0);
+    }
+
+    @Test
+    public void command_withScreenshot_syncUpload() throws IOException {
+        tested.setAsyncUpload(false);
+        Path tempFile = Files.createTempFile("temp_", ".png");
+        String uploadUrl = "https://some.s3.address.com/bucket-name/artifact/tenant/externalId/filename.png?someParam1=someParamValue1";
+        Command command = new Command.Builder()
+                .withName("cmd")
+                .withScreenshotAttachments(new ScreenshotAttachment.Builder().withAbsolutePath(tempFile.toString()).build())
+                .build();
+
+        mockPost();
+        mockGet(uploadUrl);
+        Capture<URI> putUriCapture = EasyMock.newCapture();
+        Capture<Header> headerCapture = EasyMock.newCapture();
+        expect(reportingHttpClientMock.put(capture(putUriCapture), anyObject(HttpEntity.class), anyObject(Map.class), capture(headerCapture)))
+                .andReturn(getHttpResponse(200, null));
+
+        mocksControl.replay();
+        tested.command(command);
+        mocksControl.verify();
+
+        Files.delete(tempFile);
+    }
+
+    @Test
+    public void command_withScreenshotFromInputStream() throws IOException {
+        java.io.ByteArrayInputStream inputStream = new java.io.ByteArrayInputStream("fake-image-bytes".getBytes(StandardCharsets.UTF_8));
+        ScreenshotAttachment screenshot = new ScreenshotAttachment.Builder()
+                .withInputStream(inputStream)
+                .withContentType(ScreenshotAttachment.IMAGE_JPEG)
+                .withExtension("jpg")
+                .build();
+        Command command = new Command.Builder().withName("cmd").withScreenshotAttachments(screenshot).build();
+
+        String uploadUrl = "https://some.s3.address.com/bucket-name/artifact/tenant/externalId/filename.png?someParam1=someParamValue1";
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> postCapture = mockPost();
+        mockGet(uploadUrl);
+        Capture<URI> putUriCapture = EasyMock.newCapture();
+        Capture<Header> headerCapture = EasyMock.newCapture();
+        expect(reportingHttpClientMock.put(capture(putUriCapture), anyObject(HttpEntity.class), anyObject(Map.class), capture(headerCapture)))
+                .andReturn(getHttpResponse(200, null));
+
+        mocksControl.replay();
+        tested.command(command);
+        mocksControl.verify();
+
+        String json = IOUtils.toString(postCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        CommandEvent commandEvent = gson.fromJson(json, CommandEvent.class);
+        assertEquals(commandEvent.getCommand().getScreenshots().size(), 1);
+    }
+
+    @Test
+    public void addArtifacts_withTextAttachmentFromInputStream() throws IOException {
+        java.io.ByteArrayInputStream inputStream = new java.io.ByteArrayInputStream("text content".getBytes(StandardCharsets.UTF_8));
+        TextAttachment attachment = new TextAttachment.Builder()
+                .withInputStream(inputStream)
+                .withContentType(TextAttachment.TEXT_PLAIN)
+                .withExtension("txt")
+                .withFileName("data.txt")
+                .build();
+
+        String uploadUrl = "https://some.s3.address.com/bucket-name/artifact/tenant/externalId/filename.png?someParam1=someParamValue1";
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> postCapture = mockPost();
+        mockGet(uploadUrl);
+        Capture<URI> putUriCapture = EasyMock.newCapture();
+        Capture<Header> headerCapture = EasyMock.newCapture();
+        expect(reportingHttpClientMock.put(capture(putUriCapture), anyObject(HttpEntity.class), anyObject(Map.class), capture(headerCapture)))
+                .andReturn(getHttpResponse(200, null));
+
+        mocksControl.replay();
+        tested.addArtifacts(attachment);
+        mocksControl.verify();
+
+        String json = IOUtils.toString(postCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        AddArtifactsEvent event = gson.fromJson(json, AddArtifactsEvent.class);
+        assertEquals(event.getArtifacts().size(), 1);
+    }
+
+    @Test
+    public void testStart_connectionWithCustomHeaders_includedInRequestHeaders() throws IOException {
+        Connection connection = (Connection) ReflectionTestUtils.getField(tested, "connection");
+        connection.addHeader("X-Tenant", "my-tenant");
+
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        final Header[][] capturedHeaders = new Header[1][];
+        expect(reportingHttpClientMock.post(anyObject(URI.class), anyObject(HttpEntity.class), anyObject(Map.class), anyObject(Header.class), anyObject(Header.class)))
+                .andAnswer(new IAnswer<HttpResponse>() {
+                    @Override
+                    public HttpResponse answer() throws Throwable {
+                        Object[] args = EasyMock.getCurrentArguments();
+                        capturedHeaders[0] = new Header[]{(Header) args[3], (Header) args[4]};
+                        return getHttpResponse(200, null);
+                    }
+                });
+
+        TestContext testContext = new TestContext.Builder().build();
+
+        mocksControl.replay();
+        tested.testStart("name", testContext);
+        mocksControl.verify();
+
+        Header[] headers = capturedHeaders[0];
+        boolean found = false;
+        for (Header header : headers) {
+            if ("X-Tenant".equals(header.getName()) && "my-tenant".equals(header.getValue())) {
+                found = true;
+            }
+        }
+        assertTrue(found);
+    }
+
+    @Test
+    public void testStart_asyncPostThrows_isCaughtAndLoggedWithoutPropagating() throws IOException {
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        expect(reportingHttpClientMock.post(anyObject(URI.class), anyObject(HttpEntity.class), anyObject(Map.class), anyObject(Header[].class)))
+                .andThrow(new RuntimeException("boom"));
+
+        TestContext testContext = new TestContext.Builder().build();
+        mocksControl.replay();
+        tested.testStart("name", testContext);
+        mocksControl.verify();
+    }
+
+    @Test
+    public void testStart_mergesCustomFields_testContextOverridesDuplicateExecutionField() throws IOException, URISyntaxException {
+        ImportExecutionContext executionContext = new ImportExecutionContext.Builder()
+                .withCustomFields(new CustomField("dup", "execValue"), new CustomField("uniqueExec", "execUniqueValue"))
+                .build();
+        Connection connection = new Connection(new URI(REPORTIUM_URL), SECURITY_TOKEN);
+        ReportiumImportClient localTested = new ReportiumImportClientFactory().createReportiumImportClient(connection, executionContext);
+        ReflectionTestUtils.setField(localTested, "httpClient", reportingHttpClientMock);
+        ReflectionTestUtils.setField(localTested, "executorService", executorServiceMock);
+
+        TestContext testContext = new TestContext.Builder().withCustomFields(new CustomField("dup", "testValue")).build();
+
+        mockExecutorServiceSubmitPassThrough(executorServiceMock);
+        Capture<HttpEntity> httpEntityCapture = mockPost();
+
+        mocksControl.replay();
+        localTested.testStart("my-test", testContext);
+        mocksControl.verify();
+
+        String json = IOUtils.toString(httpEntityCapture.getValue().getContent(), StandardCharsets.UTF_8);
+        TestStartEvent testStartEvent = gson.fromJson(json, TestStartEvent.class);
+
+        assertEquals(testStartEvent.getCustomFields().size(), 2);
+        boolean foundDup = false;
+        boolean foundUnique = false;
+        for (CustomField customField : testStartEvent.getCustomFields()) {
+            if ("dup".equals(customField.getName())) {
+                assertEquals(customField.getValue(), "testValue");
+                foundDup = true;
+            } else if ("uniqueExec".equals(customField.getName())) {
+                assertEquals(customField.getValue(), "execUniqueValue");
+                foundUnique = true;
+            }
+        }
+        assertTrue(foundDup);
+        assertTrue(foundUnique);
+    }
+
+    @Test(expectedExceptions = BadRequestException.class)
+    public void testStart_400Response_throwsBadRequestException() throws IOException {
+        tested.setAsyncUpload(false);
+        TestContext testContext = new TestContext.Builder().build();
+        expect(reportingHttpClientMock.post(anyObject(URI.class), anyObject(HttpEntity.class), anyObject(Map.class), anyObject(Header[].class)))
+                .andReturn(getHttpResponse(400, new StringEntity("bad request", Charset.defaultCharset())));
+
+        mocksControl.replay();
+        tested.testStart("name", testContext);
+    }
+
+    @Test(expectedExceptions = ReportiumException.class)
+    public void testStart_500Response_throwsReportiumException() throws IOException {
+        tested.setAsyncUpload(false);
+        TestContext testContext = new TestContext.Builder().build();
+        expect(reportingHttpClientMock.post(anyObject(URI.class), anyObject(HttpEntity.class), anyObject(Map.class), anyObject(Header[].class)))
+                .andReturn(getHttpResponse(500, new StringEntity("server error", Charset.defaultCharset())));
+
+        mocksControl.replay();
+        tested.testStart("name", testContext);
+    }
+
+    @Test(expectedExceptions = ReportiumException.class)
+    public void testStart_301Response_throwsReportiumException() throws IOException {
+        tested.setAsyncUpload(false);
+        TestContext testContext = new TestContext.Builder().build();
+        expect(reportingHttpClientMock.post(anyObject(URI.class), anyObject(HttpEntity.class), anyObject(Map.class), anyObject(Header[].class)))
+                .andReturn(getHttpResponse(301, new StringEntity("redirect", Charset.defaultCharset())));
+
+        mocksControl.replay();
+        tested.testStart("name", testContext);
+    }
+
+    @Test
+    public void testStart_300Response_noException() throws IOException {
+        tested.setAsyncUpload(false);
+        TestContext testContext = new TestContext.Builder().build();
+        expect(reportingHttpClientMock.post(anyObject(URI.class), anyObject(HttpEntity.class), anyObject(Map.class), anyObject(Header[].class)))
+                .andReturn(getHttpResponse(300, null));
+
+        mocksControl.replay();
+        tested.testStart("name", testContext);
+        mocksControl.verify();
+    }
+
+    @Test
+    public void close_terminatesSuccessfully() throws InterruptedException {
+        executorServiceMock.shutdown();
+        expect(executorServiceMock.awaitTermination(5, TimeUnit.MINUTES)).andReturn(true);
+        expect(executorServiceMock.isTerminated()).andReturn(true);
+
+        mocksControl.replay();
+        tested.close();
+        mocksControl.verify();
+    }
+
+    @Test
+    public void close_notTerminated_logsSevere() throws InterruptedException {
+        executorServiceMock.shutdown();
+        expect(executorServiceMock.awaitTermination(5, TimeUnit.MINUTES)).andReturn(false);
+        expect(executorServiceMock.isTerminated()).andReturn(false);
+
+        mocksControl.replay();
+        tested.close();
+        mocksControl.verify();
+    }
+
+    @Test
+    public void close_interrupted_logsSevere() throws InterruptedException {
+        executorServiceMock.shutdown();
+        expect(executorServiceMock.awaitTermination(5, TimeUnit.MINUTES)).andThrow(new InterruptedException("boom"));
+        expect(executorServiceMock.isTerminated()).andReturn(false);
+
+        mocksControl.replay();
+        tested.close();
+        mocksControl.verify();
+    }
+
+    @Test
+    public void quit_delegatesToClose() throws InterruptedException {
+        executorServiceMock.shutdown();
+        expect(executorServiceMock.awaitTermination(5, TimeUnit.MINUTES)).andReturn(true);
+        expect(executorServiceMock.isTerminated()).andReturn(true);
+
+        mocksControl.replay();
+        tested.quit();
+        mocksControl.verify();
+    }
 
     private Capture<HttpEntity> mockPost() {
         Capture<HttpEntity> httpEntityCapture = EasyMock.newCapture();

--- a/reportium-import-java/src/test/java/com/perfecto/reportium/imports/client/connection/ConnectionTest.java
+++ b/reportium-import-java/src/test/java/com/perfecto/reportium/imports/client/connection/ConnectionTest.java
@@ -1,0 +1,94 @@
+package com.perfecto.reportium.imports.client.connection;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class ConnectionTest {
+
+    private static final URI REPORTING_SERVER = create("https://tenant.reporting.perfectomobile.com");
+    private static final String SECURITY_TOKEN = "token-123";
+
+    private static URI create(String uri) {
+        try {
+            return new URI(uri);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void constructor_setsReportingServerAndSecurityToken() {
+        Connection tested = new Connection(REPORTING_SERVER, SECURITY_TOKEN);
+
+        assertEquals(tested.getReportingServer(), REPORTING_SERVER);
+        assertEquals(tested.getSecurityToken(), SECURITY_TOKEN);
+        assertNull(tested.getProxy());
+        assertNull(tested.getCredentialsProvider());
+        assertNull(tested.getSslSocketFactory());
+        assertTrue(tested.getHeaders().isEmpty());
+    }
+
+    @Test
+    public void addHeader_addsToHeadersMap() {
+        Connection tested = new Connection(REPORTING_SERVER, SECURITY_TOKEN);
+        tested.addHeader("X-Custom", "value1");
+        tested.addHeader("X-Other", "value2");
+
+        Map<String, String> headers = tested.getHeaders();
+        assertEquals(headers.size(), 2);
+        assertEquals(headers.get("X-Custom"), "value1");
+        assertEquals(headers.get("X-Other"), "value2");
+    }
+
+    @Test
+    public void getHeaders_returnsDefensiveCopy() {
+        Connection tested = new Connection(REPORTING_SERVER, SECURITY_TOKEN);
+        tested.addHeader("X-Custom", "value1");
+
+        Map<String, String> headers = tested.getHeaders();
+        headers.put("X-Injected", "hacked");
+
+        assertEquals(tested.getHeaders().size(), 1);
+    }
+
+    @Test
+    public void setProxy_getProxy() {
+        Connection tested = new Connection(REPORTING_SERVER, SECURITY_TOKEN);
+        HttpHost proxy = new HttpHost("proxy.example.com", 8080);
+        tested.setProxy(proxy);
+
+        assertEquals(tested.getProxy(), proxy);
+    }
+
+    @Test
+    public void setCredentialsProvider_getCredentialsProvider() {
+        Connection tested = new Connection(REPORTING_SERVER, SECURITY_TOKEN);
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("user", "pass"));
+        tested.setCredentialsProvider(credentialsProvider);
+
+        assertEquals(tested.getCredentialsProvider(), credentialsProvider);
+    }
+
+    @Test
+    public void setSslSocketFactory_getSslSocketFactory() {
+        Connection tested = new Connection(REPORTING_SERVER, SECURITY_TOKEN);
+        SSLConnectionSocketFactory sslSocketFactory = SSLConnectionSocketFactory.getSocketFactory();
+        tested.setSslSocketFactory(sslSocketFactory);
+
+        assertEquals(tested.getSslSocketFactory(), sslSocketFactory);
+    }
+}

--- a/reportium-import-java/src/test/java/com/perfecto/reportium/imports/client/connection/HttpResponseTest.java
+++ b/reportium-import-java/src/test/java/com/perfecto/reportium/imports/client/connection/HttpResponseTest.java
@@ -1,0 +1,77 @@
+package com.perfecto.reportium.imports.client.connection;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.easymock.EasyMock;
+import org.easymock.IMocksControl;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
+
+public class HttpResponseTest {
+
+    private IMocksControl mocksControl;
+    private org.apache.http.HttpResponse responseEntityMock;
+    private StatusLine statusLineMock;
+
+    @BeforeMethod
+    public void beforeTest() {
+        mocksControl = EasyMock.createControl();
+        responseEntityMock = mocksControl.createMock(org.apache.http.HttpResponse.class);
+        statusLineMock = mocksControl.createMock(StatusLine.class);
+    }
+
+    @Test
+    public void getStatus() {
+        EasyMock.expect(responseEntityMock.getStatusLine()).andReturn(statusLineMock);
+        EasyMock.expect(statusLineMock.getStatusCode()).andReturn(204);
+
+        mocksControl.replay();
+        HttpResponse tested = new HttpResponse(responseEntityMock);
+        assertEquals(tested.getStatus(), 204);
+        mocksControl.verify();
+    }
+
+    @Test
+    public void getStatusReason() {
+        EasyMock.expect(responseEntityMock.getStatusLine()).andReturn(statusLineMock);
+        EasyMock.expect(statusLineMock.getReasonPhrase()).andReturn("No Content");
+
+        mocksControl.replay();
+        HttpResponse tested = new HttpResponse(responseEntityMock);
+        assertEquals(tested.getStatusReason(), "No Content");
+        mocksControl.verify();
+    }
+
+    @Test
+    public void getBody_success() throws IOException {
+        HttpEntity httpEntityMock = mocksControl.createMock(HttpEntity.class);
+        EasyMock.expect(responseEntityMock.getEntity()).andReturn(httpEntityMock);
+        EasyMock.expect(httpEntityMock.getContent()).andReturn(new ByteArrayInputStream("hello".getBytes()));
+
+        mocksControl.replay();
+        HttpResponse tested = new HttpResponse(responseEntityMock);
+        assertEquals(tested.getBody(), "hello");
+        mocksControl.verify();
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void getBody_ioException() throws IOException {
+        HttpEntity httpEntityMock = mocksControl.createMock(HttpEntity.class);
+        EasyMock.expect(responseEntityMock.getEntity()).andReturn(httpEntityMock);
+        EasyMock.expect(httpEntityMock.getContent()).andThrow(new IOException("boom"));
+
+        mocksControl.replay();
+        HttpResponse tested = new HttpResponse(responseEntityMock);
+        try {
+            tested.getBody();
+        } finally {
+            mocksControl.verify();
+        }
+    }
+}

--- a/reportium-import-java/src/test/java/com/perfecto/reportium/imports/client/connection/ReportingHttpClientTest.java
+++ b/reportium-import-java/src/test/java/com/perfecto/reportium/imports/client/connection/ReportingHttpClientTest.java
@@ -1,0 +1,207 @@
+package com.perfecto.reportium.imports.client.connection;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.message.BasicHeader;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class ReportingHttpClientTest {
+
+    private HttpServer httpServer;
+    private int port;
+    private RecordingHandler handler;
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        handler = new RecordingHandler();
+        httpServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        httpServer.createContext("/", handler);
+        httpServer.start();
+        port = httpServer.getAddress().getPort();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        httpServer.stop(0);
+    }
+
+    private Connection connectionToTestServer() throws Exception {
+        return new Connection(new URI("http://localhost:" + port + "/"), "token");
+    }
+
+    @Test
+    public void get_noParamsNoHeaders() throws Exception {
+        ReportingHttpClient tested = new ReportingHttpClient(connectionToTestServer());
+        HttpResponse response = tested.get(new URI("http://localhost:" + port + "/path"), Collections.<String, String>emptyMap());
+
+        assertEquals(response.getStatus(), 200);
+        assertEquals(handler.method, "GET");
+        assertEquals(handler.path, "/path");
+    }
+
+    @Test
+    public void get_withParamsAndHeaders() throws Exception {
+        ReportingHttpClient tested = new ReportingHttpClient(connectionToTestServer());
+        Map<String, String> params = new HashMap<>();
+        params.put("a", "1");
+        params.put("b", "2");
+
+        HttpResponse response = tested.get(new URI("http://localhost:" + port + "/path"), params, new BasicHeader("X-Test", "hello"));
+
+        assertEquals(response.getStatus(), 200);
+        assertEquals(handler.method, "GET");
+        assertTrue(handler.query.contains("a=1"));
+        assertTrue(handler.query.contains("b=2"));
+        assertTrue(handler.requestHeaders.containsKey("X-Test"));
+        assertEquals(handler.requestHeaders.get("X-Test").get(0), "hello");
+    }
+
+    @Test
+    public void post_withEntityAndHeaders() throws Exception {
+        ReportingHttpClient tested = new ReportingHttpClient(connectionToTestServer());
+        Map<String, String> params = new HashMap<>();
+        params.put("p", "v");
+        StringEntity entity = new StringEntity("post-body-content", StandardCharsets.UTF_8);
+
+        HttpResponse response = tested.post(new URI("http://localhost:" + port + "/postpath"), entity, params, new BasicHeader("X-One", "1"), new BasicHeader("X-Two", "2"));
+
+        assertEquals(response.getStatus(), 200);
+        assertEquals(handler.method, "POST");
+        assertEquals(handler.path, "/postpath");
+        assertTrue(handler.query.contains("p=v"));
+        assertEquals(handler.body, "post-body-content");
+        assertTrue(handler.requestHeaders.containsKey("X-One"));
+        assertTrue(handler.requestHeaders.containsKey("X-Two"));
+    }
+
+    @Test
+    public void post_noParamsNoHeaders() throws Exception {
+        ReportingHttpClient tested = new ReportingHttpClient(connectionToTestServer());
+        StringEntity entity = new StringEntity("body", StandardCharsets.UTF_8);
+
+        HttpResponse response = tested.post(new URI("http://localhost:" + port + "/postpath"), entity, Collections.<String, String>emptyMap());
+
+        assertEquals(response.getStatus(), 200);
+        assertEquals(handler.method, "POST");
+        assertEquals(handler.body, "body");
+    }
+
+    @Test
+    public void put_withEntityAndHeaders() throws Exception {
+        ReportingHttpClient tested = new ReportingHttpClient(connectionToTestServer());
+        Map<String, String> params = new HashMap<>();
+        params.put("q", "w");
+        StringEntity entity = new StringEntity("put-body-content", StandardCharsets.UTF_8);
+
+        HttpResponse response = tested.put(new URI("http://localhost:" + port + "/putpath"), entity, params, new BasicHeader("X-Put", "yes"));
+
+        assertEquals(response.getStatus(), 200);
+        assertEquals(handler.method, "PUT");
+        assertEquals(handler.path, "/putpath");
+        assertTrue(handler.query.contains("q=w"));
+        assertEquals(handler.body, "put-body-content");
+        assertTrue(handler.requestHeaders.containsKey("X-Put"));
+    }
+
+    @Test
+    public void put_noParamsNoHeaders() throws Exception {
+        ReportingHttpClient tested = new ReportingHttpClient(connectionToTestServer());
+        StringEntity entity = new StringEntity("body", StandardCharsets.UTF_8);
+
+        HttpResponse response = tested.put(new URI("http://localhost:" + port + "/putpath"), entity, Collections.<String, String>emptyMap());
+
+        assertEquals(response.getStatus(), 200);
+        assertEquals(handler.method, "PUT");
+    }
+
+    @Test
+    public void get_withCredentialsProviderAndSslSocketFactory_success() throws Exception {
+        Connection connection = connectionToTestServer();
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("user", "pass"));
+        connection.setCredentialsProvider(credentialsProvider);
+        connection.setSslSocketFactory(SSLConnectionSocketFactory.getSocketFactory());
+
+        ReportingHttpClient tested = new ReportingHttpClient(connection);
+        HttpResponse response = tested.get(new URI("http://localhost:" + port + "/path"), Collections.<String, String>emptyMap());
+
+        assertEquals(response.getStatus(), 200);
+        assertEquals(handler.method, "GET");
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void get_withUnreachableProxy_throwsRuntimeException() throws Exception {
+        Connection connection = connectionToTestServer();
+        connection.setProxy(new HttpHost("localhost", 1));
+
+        ReportingHttpClient tested = new ReportingHttpClient(connection);
+        tested.get(new URI("http://localhost:" + port + "/path"), Collections.<String, String>emptyMap());
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void post_withUnreachableProxy_throwsRuntimeException() throws Exception {
+        Connection connection = connectionToTestServer();
+        connection.setProxy(new HttpHost("localhost", 1));
+
+        ReportingHttpClient tested = new ReportingHttpClient(connection);
+        tested.post(new URI("http://localhost:" + port + "/path"), new StringEntity("body", StandardCharsets.UTF_8), Collections.<String, String>emptyMap());
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void put_withUnreachableProxy_throwsRuntimeException() throws Exception {
+        Connection connection = connectionToTestServer();
+        connection.setProxy(new HttpHost("localhost", 1));
+
+        ReportingHttpClient tested = new ReportingHttpClient(connection);
+        tested.put(new URI("http://localhost:" + port + "/path"), new StringEntity("body", StandardCharsets.UTF_8), Collections.<String, String>emptyMap());
+    }
+
+    private static class RecordingHandler implements HttpHandler {
+        private volatile String method;
+        private volatile String path;
+        private volatile String query;
+        private volatile Map<String, List<String>> requestHeaders;
+        private volatile String body;
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            method = exchange.getRequestMethod();
+            path = exchange.getRequestURI().getPath();
+            query = exchange.getRequestURI().getRawQuery();
+            requestHeaders = exchange.getRequestHeaders();
+            body = IOUtils.toString(exchange.getRequestBody(), StandardCharsets.UTF_8);
+
+            byte[] responseBytes = "OK".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, responseBytes.length);
+            OutputStream os = exchange.getResponseBody();
+            os.write(responseBytes);
+            os.close();
+        }
+    }
+}

--- a/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/ImportExecutionContextTest.java
+++ b/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/ImportExecutionContextTest.java
@@ -131,4 +131,68 @@ public class ImportExecutionContextTest {
 
         assertEquals(0, context.getPlatforms().size());
     }
+
+    @Test
+    public void withPlatforms_nullVarargsArray_noOp() {
+        ImportExecutionContext context = new ImportExecutionContext.Builder()
+                .withPlatforms((Platform[]) null)
+                .build();
+
+        assertEquals(0, context.getPlatforms().size());
+    }
+
+    @Test
+    public void withPlatforms_nullCollection_noOp() {
+        ImportExecutionContext context = new ImportExecutionContext.Builder()
+                .withPlatforms((java.util.Collection<Platform>) null)
+                .build();
+
+        assertEquals(0, context.getPlatforms().size());
+    }
+
+    @Test
+    public void withPlatforms_multiplePlatforms() {
+        Platform platform1 = new Platform.Builder().withDeviceId("device-1").build();
+        Platform platform2 = new Platform.Builder().withDeviceId("device-2").build();
+        ImportExecutionContext context = new ImportExecutionContext.Builder()
+                .withPlatforms(platform1, platform2)
+                .build();
+
+        assertEquals(2, context.getPlatforms().size());
+    }
+
+    @Test
+    public void withAutomationFramework() {
+        ImportExecutionContext context = new ImportExecutionContext.Builder()
+                .withAutomationFramework("Selenium")
+                .build();
+
+        assertEquals("Selenium", context.getAutomationFramework());
+    }
+
+    @Test
+    public void getExternalId() {
+        ImportExecutionContext context = new ImportExecutionContext.Builder()
+                .withExternalId("ext-1")
+                .build();
+
+        assertEquals("ext-1", context.getExternalId());
+    }
+
+    @Test
+    public void updatePlatforms_seleniumCapabilities_unknownBrowserType() {
+        ImportExecutionContext context = new ImportExecutionContext.Builder().build();
+
+        Map<String, String> capabilities = new HashMap<>();
+        capabilities.put(SELENIUM_BROWSER_NAME, "SomeUnknownBrowser");
+        capabilities.put(SELENIUM_VERSION, "1.0");
+        context.updatePlatforms(capabilities);
+
+        assertEquals(1, context.getPlatforms().size());
+        Platform platform = context.getPlatforms().iterator().next();
+        BrowserInfo browserInfo = platform.getBrowserInfo();
+        assertNotNull(browserInfo);
+        assertNull(browserInfo.getBrowserType());
+        assertNull(platform.getOs());
+    }
 }

--- a/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/attachment/ScreenshotAttachmentTest.java
+++ b/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/attachment/ScreenshotAttachmentTest.java
@@ -153,6 +153,28 @@ public class ScreenshotAttachmentTest {
     }
 
     @Test
+    public void build_stream_guessExtension_png() {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("test".getBytes());
+        String extension = "png";
+        ContentType contentType = ScreenshotAttachment.IMAGE_PNG;
+        ScreenshotAttachment attachment = new ScreenshotAttachment.Builder()
+                .withContentType(contentType)
+                .withInputStream(inputStream)
+                .build();
+        assertNotNull(attachment.getInputStream());
+        assertEquals(extension, attachment.getExtension());
+        assertEquals(contentType, attachment.getContentType());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void build_stream_noExtensionNoContentType_throws() {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("test".getBytes());
+        new ScreenshotAttachment.Builder()
+                .withInputStream(inputStream)
+                .build();
+    }
+
+    @Test
     public void build_stream_guessExtension() {
         ByteArrayInputStream inputStream = new ByteArrayInputStream("test".getBytes());
         String extension = "jpg";

--- a/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/attachment/TextAttachmentTest.java
+++ b/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/attachment/TextAttachmentTest.java
@@ -1,0 +1,208 @@
+package com.perfecto.reportium.imports.model.attachment;
+
+import org.apache.http.entity.ContentType;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TextAttachmentTest {
+
+    @Test
+    public void build_stream_explicitEverything() {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("test".getBytes());
+        TextAttachment attachment = new TextAttachment.Builder()
+                .withFileName("CheckMeOut.txt")
+                .withContentType(TextAttachment.TEXT_PLAIN)
+                .withExtension("txt")
+                .withInputStream(inputStream)
+                .build();
+
+        assertEquals(attachment.getFileName(), "CheckMeOut.txt");
+        assertEquals(attachment.getContentType(), TextAttachment.TEXT_PLAIN);
+        assertEquals(attachment.getExtension(), "txt");
+        assertFalse(attachment.isZipped());
+        assertTrue(attachment.shouldZip());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void build_stream_noFileName_throws() {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("test".getBytes());
+        new TextAttachment.Builder()
+                .withContentType(TextAttachment.TEXT_PLAIN)
+                .withExtension("txt")
+                .withInputStream(inputStream)
+                .build();
+    }
+
+    @Test
+    public void build_stream_guessExtensionFromContentType_textPlain() {
+        assertGuessedExtension(TextAttachment.TEXT_PLAIN, "txt");
+    }
+
+    @Test
+    public void build_stream_guessExtensionFromContentType_richText() {
+        assertGuessedExtension(TextAttachment.TEXT_RICHTEXT, "rtf");
+    }
+
+    @Test
+    public void build_stream_guessExtensionFromContentType_html() {
+        assertGuessedExtension(TextAttachment.TEXT_HTML, "html");
+    }
+
+    @Test
+    public void build_stream_guessExtensionFromContentType_csv() {
+        assertGuessedExtension(TextAttachment.TEXT_CSV, "csv");
+    }
+
+    @Test
+    public void build_stream_guessExtensionFromContentType_xml() {
+        assertGuessedExtension(TextAttachment.APPLICATION_XML, "xml");
+    }
+
+    @Test
+    public void build_stream_guessExtensionFromContentType_json() {
+        assertGuessedExtension(TextAttachment.APPLICATION_JSON, "json");
+    }
+
+    private void assertGuessedExtension(ContentType contentType, String expectedExtension) {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("test".getBytes());
+        TextAttachment attachment = new TextAttachment.Builder()
+                .withFileName("CheckMeOut")
+                .withContentType(contentType)
+                .withInputStream(inputStream)
+                .build();
+
+        assertEquals(attachment.getExtension(), expectedExtension);
+        assertEquals(attachment.getContentType(), contentType);
+    }
+
+    @Test
+    public void build_stream_guessContentTypeFromExtension_txt() {
+        assertGuessedContentType("txt", TextAttachment.TEXT_PLAIN);
+    }
+
+    @Test
+    public void build_stream_guessContentTypeFromExtension_log() {
+        assertGuessedContentType("log", TextAttachment.TEXT_PLAIN);
+    }
+
+    @Test
+    public void build_stream_guessContentTypeFromExtension_rt() {
+        assertGuessedContentType("rt", TextAttachment.TEXT_RICHTEXT);
+    }
+
+    @Test
+    public void build_stream_guessContentTypeFromExtension_rtf() {
+        assertGuessedContentType("rtf", TextAttachment.TEXT_RICHTEXT);
+    }
+
+    @Test
+    public void build_stream_guessContentTypeFromExtension_html() {
+        assertGuessedContentType("html", TextAttachment.TEXT_HTML);
+    }
+
+    @Test
+    public void build_stream_guessContentTypeFromExtension_csv() {
+        assertGuessedContentType("csv", TextAttachment.TEXT_CSV);
+    }
+
+    @Test
+    public void build_stream_guessContentTypeFromExtension_xml() {
+        assertGuessedContentType("xml", TextAttachment.APPLICATION_XML);
+    }
+
+    @Test
+    public void build_stream_guessContentTypeFromExtension_json() {
+        assertGuessedContentType("json", TextAttachment.APPLICATION_JSON);
+    }
+
+    @Test
+    public void build_stream_guessContentTypeFromExtension_uppercase() {
+        assertGuessedContentType("TXT", TextAttachment.TEXT_PLAIN);
+    }
+
+    private void assertGuessedContentType(String extension, ContentType expectedContentType) {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("test".getBytes());
+        TextAttachment attachment = new TextAttachment.Builder()
+                .withFileName("CheckMeOut")
+                .withExtension(extension)
+                .withInputStream(inputStream)
+                .build();
+
+        assertEquals(attachment.getContentType(), expectedContentType);
+        assertEquals(attachment.getExtension(), extension);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void build_stream_contentTypeNotAllowed_throws() {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("test".getBytes());
+        new TextAttachment.Builder()
+                .withFileName("CheckMeOut.bin")
+                .withContentType(ContentType.APPLICATION_OCTET_STREAM)
+                .withExtension("bin")
+                .withInputStream(inputStream)
+                .build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void build_stream_noContentTypeNoExtension_throws() {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("test".getBytes());
+        new TextAttachment.Builder()
+                .withFileName("CheckMeOut")
+                .withInputStream(inputStream)
+                .build();
+    }
+
+    @Test
+    public void build_file_guessExtensionZippedAndFileNameFromPath() throws IOException {
+        Path tempFile = Files.createTempFile("test", ".zip");
+        try {
+            TextAttachment attachment = new TextAttachment.Builder()
+                    .withContentType(TextAttachment.TEXT_PLAIN)
+                    .withAbsolutePath(tempFile.toString())
+                    .build();
+
+            assertEquals(attachment.getAbsolutePath(), tempFile.toString());
+            assertEquals(attachment.getExtension(), "zip");
+            assertEquals(attachment.getFileName(), tempFile.getFileName().toString());
+            assertTrue(attachment.isZipped());
+            assertFalse(attachment.shouldZip());
+        } finally {
+            Files.delete(tempFile);
+        }
+    }
+
+    @Test
+    public void build_file_guessEverythingFromPath() throws IOException {
+        Path tempFile = Files.createTempFile("test", ".csv");
+        try {
+            TextAttachment attachment = new TextAttachment.Builder()
+                    .withAbsolutePath(tempFile.toString())
+                    .build();
+
+            assertEquals(attachment.getExtension(), "csv");
+            assertEquals(attachment.getContentType(), TextAttachment.TEXT_CSV);
+            assertEquals(attachment.getFileName(), tempFile.getFileName().toString());
+            assertFalse(attachment.isZipped());
+            assertTrue(attachment.shouldZip());
+        } finally {
+            Files.delete(tempFile);
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void build_file_fileNotFound_throws() {
+        new TextAttachment.Builder()
+                .withContentType(TextAttachment.TEXT_PLAIN)
+                .withExtension("txt")
+                .withAbsolutePath("/no/such/file-" + System.nanoTime() + ".txt")
+                .build();
+    }
+}

--- a/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/command/CommandTest.java
+++ b/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/command/CommandTest.java
@@ -3,7 +3,13 @@ package com.perfecto.reportium.imports.model.command;
 import com.perfecto.reportium.imports.model.attachment.ScreenshotAttachment;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class CommandTest {
@@ -14,8 +20,28 @@ public class CommandTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
+    public void withEmptyName() {
+        new Command.Builder().withName("").withStatus(CommandStatus.SUCCESS).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void withNoStatus() {
         new Command.Builder().withName("slim shady").withStatus(null).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void withNoCommandType() {
+        new Command.Builder().withName("slim shady").withCommandType(null).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void withNegativeStartTime() {
+        new Command.Builder().withName("slim shady").withStartTime(-1).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void withNegativeEndTime() {
+        new Command.Builder().withName("slim shady").withEndTime(-1).build();
     }
 
     @Test
@@ -26,9 +52,113 @@ public class CommandTest {
     }
 
     @Test
+    public void withNullScreenshotsVarargs() {
+        Command command = new Command.Builder().withName("xxx").withScreenshotAttachments((ScreenshotAttachment[]) null).build();
+        assertEquals(0, command.getScreenshots().size());
+    }
+
+    @Test
+    public void withEmptyScreenshotsCollection() {
+        Command command = new Command.Builder().withName("xxx").withScreenshotAttachments(Collections.<ScreenshotAttachment>emptyList()).build();
+        assertEquals(0, command.getScreenshots().size());
+    }
+
+    @Test
+    public void withNullScreenshotsCollection() {
+        List<ScreenshotAttachment> screenshots = null;
+        Command command = new Command.Builder().withName("xxx").withScreenshotAttachments(screenshots).build();
+        assertEquals(0, command.getScreenshots().size());
+    }
+
+    @Test
     public void withNullParameter() {
         CommandParameter parameter = null;
         Command command = new Command.Builder().withName("xxx").withParameters(parameter).build();
         assertEquals(0, command.getParameters().size());
+    }
+
+    @Test
+    public void withNullParametersVarargs() {
+        Command command = new Command.Builder().withName("xxx").withParameters((CommandParameter[]) null).build();
+        assertEquals(0, command.getParameters().size());
+    }
+
+    @Test
+    public void withEmptyParametersCollection() {
+        Command command = new Command.Builder().withName("xxx").withParameters(Collections.<CommandParameter>emptyList()).build();
+        assertEquals(0, command.getParameters().size());
+    }
+
+    @Test
+    public void withNullParametersCollection() {
+        List<CommandParameter> parameters = null;
+        Command command = new Command.Builder().withName("xxx").withParameters(parameters).build();
+        assertEquals(0, command.getParameters().size());
+    }
+
+    @Test
+    public void addParameter_addsSingleParameter() {
+        CommandParameter parameter = new CommandParameter("name", "value");
+        Command command = new Command.Builder().withName("xxx").addParameter(parameter).build();
+        assertEquals(command.getParameters(), Arrays.asList(parameter));
+    }
+
+    @Test
+    public void addScreenshotAttachment_addsSingleScreenshot() throws Exception {
+        java.nio.file.Path tempFile = java.nio.file.Files.createTempFile("test", ".jpg");
+        try {
+            ScreenshotAttachment screenshot = new ScreenshotAttachment.Builder().withAbsolutePath(tempFile.toString()).build();
+            Command command = new Command.Builder().withName("xxx").addScreenshotAttachment(screenshot).build();
+            assertEquals(command.getScreenshots(), Arrays.asList(screenshot));
+        } finally {
+            java.nio.file.Files.delete(tempFile);
+        }
+    }
+
+    @Test
+    public void normalizeCommand_bothTimesZero_setToCurrentTime() {
+        Command command = new Command.Builder().withName("xxx").build();
+        assertTrue(command.getStartTime() > 0);
+        assertEquals(command.getStartTime(), command.getEndTime());
+    }
+
+    @Test
+    public void normalizeCommand_onlyStartTimeSet_endTimeCopiesStart() {
+        Command command = new Command.Builder().withName("xxx").withStartTime(100).build();
+        assertEquals(command.getStartTime(), 100);
+        assertEquals(command.getEndTime(), 100);
+    }
+
+    @Test
+    public void normalizeCommand_onlyEndTimeSet_startTimeCopiesEnd() {
+        Command command = new Command.Builder().withName("xxx").withEndTime(200).build();
+        assertEquals(command.getStartTime(), 200);
+        assertEquals(command.getEndTime(), 200);
+    }
+
+    @Test
+    public void normalizeCommand_bothTimesSet_notModified() {
+        Command command = new Command.Builder().withName("xxx").withStartTime(100).withEndTime(200).build();
+        assertEquals(command.getStartTime(), 100);
+        assertEquals(command.getEndTime(), 200);
+    }
+
+    @Test
+    public void build_allFieldsAccessible() {
+        Command command = new Command.Builder()
+                .withName("cmd")
+                .withStatus(CommandStatus.FAILURE)
+                .withMessage("msg")
+                .withStartTime(1)
+                .withEndTime(2)
+                .withCommandType(CommandType.API)
+                .build();
+
+        assertEquals(command.getName(), "cmd");
+        assertEquals(command.getStatus(), CommandStatus.FAILURE);
+        assertEquals(command.getMessage(), "msg");
+        assertEquals(command.getCommandType(), CommandType.API);
+        assertNotNull(command.getParameters());
+        assertNotNull(command.getScreenshots());
     }
 }

--- a/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/platform/BrowserTypeTest.java
+++ b/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/platform/BrowserTypeTest.java
@@ -3,6 +3,7 @@ package com.perfecto.reportium.imports.model.platform;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 public class BrowserTypeTest {
 
@@ -21,5 +22,35 @@ public class BrowserTypeTest {
 
         browserType = BrowserType.getByName("INTERNET_EXPLORER");
         assertEquals(BrowserType.INTERNET_EXPLORER, browserType);
+    }
+
+    @Test
+    public void getByName_null_returnsNull() {
+        assertNull(BrowserType.getByName(null));
+    }
+
+    @Test
+    public void getByName_unknownName_returnsNull() {
+        assertNull(BrowserType.getByName("some unknown browser"));
+    }
+
+    @Test
+    public void getByName_chrome() {
+        assertEquals(BrowserType.getByName("chrome"), BrowserType.CHROME);
+    }
+
+    @Test
+    public void getByName_firefox() {
+        assertEquals(BrowserType.getByName("firefox"), BrowserType.FIREFOX);
+    }
+
+    @Test
+    public void getByName_safari() {
+        assertEquals(BrowserType.getByName("safari"), BrowserType.SAFARI);
+    }
+
+    @Test
+    public void getByName_microsoftEdge() {
+        assertEquals(BrowserType.getByName("microsoft edge"), BrowserType.MICROSOFT_EDGE);
     }
 }

--- a/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/platform/PlatformTest.java
+++ b/reportium-import-java/src/test/java/com/perfecto/reportium/imports/model/platform/PlatformTest.java
@@ -1,0 +1,109 @@
+package com.perfecto.reportium.imports.model.platform;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class PlatformTest {
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void build_withBothMobileAndBrowserInfo_throws() {
+        new Platform.Builder()
+                .withMobileInfo(new MobileInfo.Builder().withModel("model").build())
+                .withBrowserInfo(new BrowserInfo.Builder().withBrowserType(BrowserType.CHROME).build())
+                .build();
+    }
+
+    @Test
+    public void build_withMobileInfo_normalizesDeviceTypeToMobile() {
+        MobileInfo mobileInfo = new MobileInfo.Builder().withModel("iPhone").build();
+        Platform platform = new Platform.Builder()
+                .withMobileInfo(mobileInfo)
+                .build();
+
+        assertEquals(platform.getDeviceType(), DeviceType.MOBILE);
+        assertEquals(platform.getMobileInfo(), mobileInfo);
+        assertNull(platform.getBrowserInfo());
+    }
+
+    @Test
+    public void build_withBrowserInfo_normalizesDeviceTypeToDesktop() {
+        BrowserInfo browserInfo = new BrowserInfo.Builder().withBrowserType(BrowserType.CHROME).build();
+        Platform platform = new Platform.Builder()
+                .withBrowserInfo(browserInfo)
+                .build();
+
+        assertEquals(platform.getDeviceType(), DeviceType.DESKTOP);
+        assertEquals(platform.getBrowserInfo(), browserInfo);
+        assertNull(platform.getMobileInfo());
+    }
+
+    @Test
+    public void build_withExplicitDeviceType_doesNotNormalize() {
+        MobileInfo mobileInfo = new MobileInfo.Builder().withModel("iPhone").build();
+        Platform platform = new Platform.Builder()
+                .withDeviceType(DeviceType.DESKTOP)
+                .withMobileInfo(mobileInfo)
+                .build();
+
+        assertEquals(platform.getDeviceType(), DeviceType.DESKTOP);
+    }
+
+    @Test
+    public void build_withNoMobileOrBrowserInfo_deviceTypeStaysNull() {
+        Platform platform = new Platform.Builder().build();
+        assertNull(platform.getDeviceType());
+        assertNull(platform.getMobileInfo());
+        assertNull(platform.getBrowserInfo());
+    }
+
+    @Test
+    public void build_allFieldsSet() {
+        Platform platform = new Platform.Builder()
+                .withDeviceId("device-1")
+                .withOs("Android")
+                .withOsVersion("10")
+                .withScreenResolution("1080x1920")
+                .withLocation("US")
+                .build();
+
+        assertEquals(platform.getDeviceId(), "device-1");
+        assertEquals(platform.getOs(), "Android");
+        assertEquals(platform.getOsVersion(), "10");
+        assertEquals(platform.getScreenResolution(), "1080x1920");
+        assertEquals(platform.getLocation(), "US");
+    }
+
+    @Test
+    public void copyConstructor_copiesAllFields() {
+        Platform original = new Platform.Builder()
+                .withDeviceId("device-1")
+                .withOs("Android")
+                .withOsVersion("10")
+                .withScreenResolution("1080x1920")
+                .withLocation("US")
+                .withMobileInfo(new MobileInfo.Builder().withModel("Pixel").build())
+                .build();
+
+        Platform copy = new Platform.Builder(original).build();
+
+        assertEquals(copy, original);
+    }
+
+    @Test
+    public void equals_and_hashCode() {
+        Platform platform1 = new Platform.Builder().withDeviceId("device-1").withOs("Android").build();
+        Platform platform2 = new Platform.Builder().withDeviceId("device-1").withOs("Android").build();
+        Platform platform3 = new Platform.Builder().withDeviceId("device-2").withOs("iOS").build();
+
+        assertTrue(platform1.equals(platform1));
+        assertTrue(platform1.equals(platform2));
+        assertEquals(platform1.hashCode(), platform2.hashCode());
+        assertFalse(platform1.equals(platform3));
+        assertFalse(platform1.equals(null));
+        assertFalse(platform1.equals("not a platform"));
+    }
+}

--- a/reportium-import-selenium/pom.xml
+++ b/reportium-import-selenium/pom.xml
@@ -31,6 +31,21 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/reportium-import-selenium/src/test/java/selenium/PerfectoEventFiringWebDriverTest.java
+++ b/reportium-import-selenium/src/test/java/selenium/PerfectoEventFiringWebDriverTest.java
@@ -1,0 +1,168 @@
+package selenium;
+
+import com.perfecto.reportium.imports.client.ReportiumImportClient;
+import com.perfecto.reportium.imports.model.ImportExecutionContext;
+import org.easymock.EasyMock;
+import org.easymock.IMocksControl;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.interactions.Keyboard;
+import org.openqa.selenium.interactions.Mouse;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test case for {@link PerfectoEventFiringWebDriver}.
+ */
+public class PerfectoEventFiringWebDriverTest {
+
+    private IMocksControl mocksControl;
+
+    @BeforeMethod
+    public void beforeMethod() {
+        mocksControl = EasyMock.createControl();
+    }
+
+    @Test
+    public void constructor_withPlainWebDriver_wrapsDriver() {
+        WebDriver driverMock = mocksControl.createMock(WebDriver.class);
+        mocksControl.replay();
+
+        PerfectoEventFiringWebDriver tested = new PerfectoEventFiringWebDriver(driverMock);
+
+        mocksControl.verify();
+        assertSame(tested.getWrappedDriver(), driverMock);
+    }
+
+    @Test
+    public void constructor_withNonRemoteWebDriver_skipsPlatformUpdateButRegistersListener() {
+        WebDriver driverMock = mocksControl.createMock(WebDriver.class);
+        ReportiumImportClient reportiumImportClientMock = mocksControl.createMock(ReportiumImportClient.class);
+        // getExecutionContext() must never be called since driver is not a RemoteWebDriver
+        mocksControl.replay();
+
+        PerfectoEventFiringWebDriver tested = new PerfectoEventFiringWebDriver(driverMock, reportiumImportClientMock);
+
+        mocksControl.verify();
+
+        Object listener = ReflectionTestUtils.getField(tested, "perfectoWebDriverListener");
+        assertTrue(listener instanceof PerfectoWebDriverEventListenerImpl);
+
+        @SuppressWarnings("unchecked")
+        List<Object> eventListeners = (List<Object>) ReflectionTestUtils.getField(tested, "eventListeners");
+        assertTrue(eventListeners.contains(listener));
+    }
+
+    @Test
+    public void constructor_withRemoteWebDriver_updatesPlatformsAndRegistersListener() {
+        RemoteWebDriver remoteDriverMock = mocksControl.createMock(RemoteWebDriver.class);
+        Capabilities capabilitiesMock = mocksControl.createMock(Capabilities.class);
+        ReportiumImportClient reportiumImportClientMock = mocksControl.createMock(ReportiumImportClient.class);
+        ImportExecutionContext executionContext = new ImportExecutionContext.Builder().build();
+
+        Map<String, Object> capabilitiesMap = new HashMap<String, Object>();
+        capabilitiesMap.put(ImportExecutionContext.SELENIUM_VERSION, "99");
+        capabilitiesMap.put(ImportExecutionContext.SELENIUM_BROWSER_NAME, "chrome");
+        capabilitiesMap.put(ImportExecutionContext.SELENIUM_PLATFORM, "LINUX");
+
+        EasyMock.expect(remoteDriverMock.getCapabilities()).andReturn(capabilitiesMock);
+        EasyMock.expect(capabilitiesMock.asMap()).andReturn(capabilitiesMap);
+        EasyMock.expect(reportiumImportClientMock.getExecutionContext()).andReturn(executionContext).anyTimes();
+        mocksControl.replay();
+
+        PerfectoEventFiringWebDriver tested = new PerfectoEventFiringWebDriver(remoteDriverMock, reportiumImportClientMock);
+
+        mocksControl.verify();
+        // the platforms list was populated as a side effect of the RemoteWebDriver branch
+        assertFalse(executionContext.getPlatforms().isEmpty());
+
+        Object listener = ReflectionTestUtils.getField(tested, "perfectoWebDriverListener");
+        assertTrue(listener instanceof PerfectoWebDriverEventListenerImpl);
+    }
+
+    @Test
+    public void getKeyboard_wrapsUnderlyingKeyboardWithPerfectoKeyboard() {
+        RemoteWebDriver remoteDriverMock = mocksControl.createMock(RemoteWebDriver.class);
+        Capabilities capabilitiesMock = mocksControl.createMock(Capabilities.class);
+        ReportiumImportClient reportiumImportClientMock = mocksControl.createMock(ReportiumImportClient.class);
+        Keyboard keyboardMock = mocksControl.createMock(Keyboard.class);
+        ImportExecutionContext executionContext = new ImportExecutionContext.Builder().build();
+
+        EasyMock.expect(remoteDriverMock.getCapabilities()).andReturn(capabilitiesMock);
+        EasyMock.expect(capabilitiesMock.asMap()).andReturn(new HashMap<String, Object>());
+        EasyMock.expect(reportiumImportClientMock.getExecutionContext()).andReturn(executionContext).anyTimes();
+        EasyMock.expect(remoteDriverMock.getKeyboard()).andReturn(keyboardMock);
+        mocksControl.replay();
+
+        PerfectoEventFiringWebDriver tested = new PerfectoEventFiringWebDriver(remoteDriverMock, reportiumImportClientMock);
+        Keyboard result = tested.getKeyboard();
+
+        mocksControl.verify();
+        assertTrue(result instanceof PerfectoKeyboard);
+        // super.getKeyboard() wraps the raw driver keyboard in Selenium's own EventFiringKeyboard;
+        // dig one level further to confirm it ultimately delegates to our mock.
+        Object eventFiringKeyboard = ReflectionTestUtils.getField(result, "keyboard");
+        Object wrappedKeyboard = ReflectionTestUtils.getField(eventFiringKeyboard, "keyboard");
+        assertSame(wrappedKeyboard, keyboardMock);
+        Object wrappedListener = ReflectionTestUtils.getField(result, "listener");
+        assertSame(wrappedListener, ReflectionTestUtils.getField(tested, "perfectoWebDriverListener"));
+    }
+
+    @Test
+    public void getMouse_wrapsUnderlyingMouseWithPerfectoMouse() {
+        RemoteWebDriver remoteDriverMock = mocksControl.createMock(RemoteWebDriver.class);
+        Capabilities capabilitiesMock = mocksControl.createMock(Capabilities.class);
+        ReportiumImportClient reportiumImportClientMock = mocksControl.createMock(ReportiumImportClient.class);
+        Mouse mouseMock = mocksControl.createMock(Mouse.class);
+        ImportExecutionContext executionContext = new ImportExecutionContext.Builder().build();
+
+        EasyMock.expect(remoteDriverMock.getCapabilities()).andReturn(capabilitiesMock);
+        EasyMock.expect(capabilitiesMock.asMap()).andReturn(new HashMap<String, Object>());
+        EasyMock.expect(reportiumImportClientMock.getExecutionContext()).andReturn(executionContext).anyTimes();
+        EasyMock.expect(remoteDriverMock.getMouse()).andReturn(mouseMock);
+        mocksControl.replay();
+
+        PerfectoEventFiringWebDriver tested = new PerfectoEventFiringWebDriver(remoteDriverMock, reportiumImportClientMock);
+        Mouse result = tested.getMouse();
+
+        mocksControl.verify();
+        assertTrue(result instanceof PerfectoMouse);
+        // super.getMouse() wraps the raw driver mouse in Selenium's own EventFiringMouse;
+        // dig one level further to confirm it ultimately delegates to our mock.
+        Object eventFiringMouse = ReflectionTestUtils.getField(result, "mouse");
+        Object wrappedMouse = ReflectionTestUtils.getField(eventFiringMouse, "mouse");
+        assertSame(wrappedMouse, mouseMock);
+        Object wrappedListener = ReflectionTestUtils.getField(result, "listener");
+        assertSame(wrappedListener, ReflectionTestUtils.getField(tested, "perfectoWebDriverListener"));
+    }
+
+    @Test
+    public void quit_notifiesListenerThenDelegatesToWrappedDriver() {
+        RemoteWebDriver remoteDriverMock = mocksControl.createMock(RemoteWebDriver.class);
+        Capabilities capabilitiesMock = mocksControl.createMock(Capabilities.class);
+        ReportiumImportClient reportiumImportClientMock = mocksControl.createMock(ReportiumImportClient.class);
+        ImportExecutionContext executionContext = new ImportExecutionContext.Builder().build();
+
+        EasyMock.expect(remoteDriverMock.getCapabilities()).andReturn(capabilitiesMock);
+        EasyMock.expect(capabilitiesMock.asMap()).andReturn(new HashMap<String, Object>());
+        EasyMock.expect(reportiumImportClientMock.getExecutionContext()).andReturn(executionContext).anyTimes();
+        reportiumImportClientMock.quit();
+        remoteDriverMock.quit();
+        mocksControl.replay();
+
+        PerfectoEventFiringWebDriver tested = new PerfectoEventFiringWebDriver(remoteDriverMock, reportiumImportClientMock);
+        tested.quit();
+
+        mocksControl.verify();
+    }
+}

--- a/reportium-import-selenium/src/test/java/selenium/PerfectoKeyboardTest.java
+++ b/reportium-import-selenium/src/test/java/selenium/PerfectoKeyboardTest.java
@@ -1,0 +1,131 @@
+package selenium;
+
+import org.easymock.EasyMock;
+import org.easymock.IMocksControl;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.interactions.Keyboard;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * Test case for {@link PerfectoKeyboard}.
+ * <p>
+ * PerfectoKeyboard is a thin delegate: every method notifies the {@link PerfectoWebDriverEventListener}
+ * before and after delegating to the wrapped {@link Keyboard}. These tests verify the call order and that
+ * both the return path and the exception path propagate correctly.
+ */
+public class PerfectoKeyboardTest {
+
+    private IMocksControl mocksControl;
+    private Keyboard keyboardMock;
+    private PerfectoWebDriverEventListener listenerMock;
+    private PerfectoKeyboard tested;
+
+    @BeforeMethod
+    public void beforeMethod() {
+        mocksControl = EasyMock.createControl();
+        keyboardMock = mocksControl.createMock(Keyboard.class);
+        listenerMock = mocksControl.createMock(PerfectoWebDriverEventListener.class);
+        tested = new PerfectoKeyboard(keyboardMock, listenerMock);
+    }
+
+    @Test
+    public void sendKeys_delegatesAndNotifiesListener() {
+        CharSequence[] keys = new CharSequence[]{"a", "b"};
+
+        listenerMock.beforeSendKeys(keys);
+        keyboardMock.sendKeys(keys);
+        listenerMock.afterSendKeys(keys);
+        mocksControl.replay();
+
+        tested.sendKeys(keys);
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void sendKeys_propagatesExceptionFromWrappedKeyboard() {
+        CharSequence[] keys = new CharSequence[]{"a"};
+        WebDriverException exception = new WebDriverException("boom");
+
+        listenerMock.beforeSendKeys(keys);
+        keyboardMock.sendKeys(keys);
+        EasyMock.expectLastCall().andThrow(exception);
+        mocksControl.replay();
+
+        try {
+            tested.sendKeys(keys);
+            fail("Expected exception to propagate");
+        } catch (WebDriverException e) {
+            assertEquals(e, exception);
+        }
+
+        // afterSendKeys must not be called since the wrapped keyboard threw
+        mocksControl.verify();
+    }
+
+    @Test
+    public void pressKey_delegatesAndNotifiesListener() {
+        listenerMock.beforePressKey("a");
+        keyboardMock.pressKey("a");
+        listenerMock.afterPressKey("a");
+        mocksControl.replay();
+
+        tested.pressKey("a");
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void pressKey_propagatesExceptionFromWrappedKeyboard() {
+        WebDriverException exception = new WebDriverException("boom");
+
+        listenerMock.beforePressKey("a");
+        keyboardMock.pressKey("a");
+        EasyMock.expectLastCall().andThrow(exception);
+        mocksControl.replay();
+
+        try {
+            tested.pressKey("a");
+            fail("Expected exception to propagate");
+        } catch (WebDriverException e) {
+            assertEquals(e, exception);
+        }
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void releaseKey_delegatesAndNotifiesListener() {
+        listenerMock.beforeReleaseKey("a");
+        keyboardMock.releaseKey("a");
+        listenerMock.afterReleaseKey("a");
+        mocksControl.replay();
+
+        tested.releaseKey("a");
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void releaseKey_propagatesExceptionFromWrappedKeyboard() {
+        WebDriverException exception = new WebDriverException("boom");
+
+        listenerMock.beforeReleaseKey("a");
+        keyboardMock.releaseKey("a");
+        EasyMock.expectLastCall().andThrow(exception);
+        mocksControl.replay();
+
+        try {
+            tested.releaseKey("a");
+            fail("Expected exception to propagate");
+        } catch (WebDriverException e) {
+            assertEquals(e, exception);
+        }
+
+        mocksControl.verify();
+    }
+}

--- a/reportium-import-selenium/src/test/java/selenium/PerfectoMouseTest.java
+++ b/reportium-import-selenium/src/test/java/selenium/PerfectoMouseTest.java
@@ -1,0 +1,159 @@
+package selenium;
+
+import org.easymock.EasyMock;
+import org.easymock.IMocksControl;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.interactions.Coordinates;
+import org.openqa.selenium.interactions.Mouse;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * Test case for {@link PerfectoMouse}.
+ * <p>
+ * PerfectoMouse is a thin delegate: every method notifies the {@link PerfectoWebDriverEventListener}
+ * before and after delegating to the wrapped {@link Mouse}. These tests verify the call order/arguments
+ * and that exceptions from the wrapped mouse propagate (without firing the "after" notification).
+ */
+public class PerfectoMouseTest {
+
+    private IMocksControl mocksControl;
+    private Mouse mouseMock;
+    private PerfectoWebDriverEventListener listenerMock;
+    private Coordinates coordinatesMock;
+    private PerfectoMouse tested;
+
+    @BeforeMethod
+    public void beforeMethod() {
+        mocksControl = EasyMock.createControl();
+        mouseMock = mocksControl.createMock(Mouse.class);
+        listenerMock = mocksControl.createMock(PerfectoWebDriverEventListener.class);
+        coordinatesMock = mocksControl.createMock(Coordinates.class);
+        tested = new PerfectoMouse(mouseMock, listenerMock);
+    }
+
+    @Test
+    public void click_delegatesAndNotifiesListener() {
+        listenerMock.beforeClick(coordinatesMock);
+        mouseMock.click(coordinatesMock);
+        listenerMock.afterClick(coordinatesMock);
+        mocksControl.replay();
+
+        tested.click(coordinatesMock);
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void click_propagatesExceptionFromWrappedMouse() {
+        WebDriverException exception = new WebDriverException("boom");
+
+        listenerMock.beforeClick(coordinatesMock);
+        mouseMock.click(coordinatesMock);
+        EasyMock.expectLastCall().andThrow(exception);
+        mocksControl.replay();
+
+        try {
+            tested.click(coordinatesMock);
+            fail("Expected exception to propagate");
+        } catch (WebDriverException e) {
+            assertEquals(e, exception);
+        }
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void doubleClick_delegatesAndNotifiesListener() {
+        listenerMock.beforeDoubleClick(coordinatesMock);
+        mouseMock.doubleClick(coordinatesMock);
+        listenerMock.afterDoubleClick(coordinatesMock);
+        mocksControl.replay();
+
+        tested.doubleClick(coordinatesMock);
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void mouseDown_delegatesAndNotifiesListener() {
+        listenerMock.beforeMouseDown();
+        mouseMock.mouseDown(coordinatesMock);
+        listenerMock.afterMouseDown();
+        mocksControl.replay();
+
+        tested.mouseDown(coordinatesMock);
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void mouseUp_delegatesAndNotifiesListener() {
+        listenerMock.beforeMouseUp(coordinatesMock);
+        mouseMock.mouseUp(coordinatesMock);
+        listenerMock.afterMouseUp(coordinatesMock);
+        mocksControl.replay();
+
+        tested.mouseUp(coordinatesMock);
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void mouseMove_delegatesAndNotifiesListener() {
+        listenerMock.beforeMouseMove(coordinatesMock);
+        mouseMock.mouseMove(coordinatesMock);
+        listenerMock.afterMouseMove(coordinatesMock);
+        mocksControl.replay();
+
+        tested.mouseMove(coordinatesMock);
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void mouseMove_withOffsets_delegatesAndNotifiesListener() {
+        listenerMock.beforeMouseMove(coordinatesMock, 5L, 10L);
+        mouseMock.mouseMove(coordinatesMock, 5L, 10L);
+        listenerMock.afterMouseMove(coordinatesMock, 5L, 10L);
+        mocksControl.replay();
+
+        tested.mouseMove(coordinatesMock, 5L, 10L);
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void mouseMove_withOffsets_propagatesExceptionFromWrappedMouse() {
+        WebDriverException exception = new WebDriverException("boom");
+
+        listenerMock.beforeMouseMove(coordinatesMock, 5L, 10L);
+        mouseMock.mouseMove(coordinatesMock, 5L, 10L);
+        EasyMock.expectLastCall().andThrow(exception);
+        mocksControl.replay();
+
+        try {
+            tested.mouseMove(coordinatesMock, 5L, 10L);
+            fail("Expected exception to propagate");
+        } catch (WebDriverException e) {
+            assertEquals(e, exception);
+        }
+
+        mocksControl.verify();
+    }
+
+    @Test
+    public void contextClick_delegatesAndNotifiesListener() {
+        listenerMock.beforeContextClick(coordinatesMock);
+        mouseMock.contextClick(coordinatesMock);
+        listenerMock.afterContextClick(coordinatesMock);
+        mocksControl.replay();
+
+        tested.contextClick(coordinatesMock);
+
+        mocksControl.verify();
+    }
+}

--- a/reportium-import-selenium/src/test/java/selenium/PerfectoWebDriverEventListenerImplTest.java
+++ b/reportium-import-selenium/src/test/java/selenium/PerfectoWebDriverEventListenerImplTest.java
@@ -1,0 +1,732 @@
+package selenium;
+
+import com.perfecto.reportium.imports.client.ReportiumImportClient;
+import com.perfecto.reportium.imports.model.command.Command;
+import com.perfecto.reportium.imports.model.command.CommandParameter;
+import com.perfecto.reportium.imports.model.command.CommandStatus;
+import org.apache.commons.codec.binary.Base64;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.easymock.IMocksControl;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.Point;
+import org.openqa.selenium.By;
+import org.openqa.selenium.interactions.Coordinates;
+import org.openqa.selenium.remote.RemoteWebElement;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static org.easymock.EasyMock.capture;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test case for {@link PerfectoWebDriverEventListenerImpl}
+ */
+public class PerfectoWebDriverEventListenerImplTest {
+
+    private IMocksControl mocksControl;
+    private ReportiumImportClient reportiumImportClientMock;
+    private PerfectoWebDriverEventListenerImpl tested;
+
+    /**
+     * Non-static inner class: instances of it carry a synthetic "this$0" field pointing at this
+     * test instance. Used to exercise the "enclosing object exists but is not a RemoteWebElement"
+     * branch of the production code's coordinates-parameter extraction.
+     */
+    private class NonRemoteElementCoordinates implements Coordinates {
+        @Override
+        public Point onScreen() {
+            return null;
+        }
+
+        @Override
+        public Point inViewPort() {
+            return null;
+        }
+
+        @Override
+        public Point onPage() {
+            return null;
+        }
+
+        @Override
+        public Object getAuxiliary() {
+            return null;
+        }
+    }
+
+    @BeforeMethod
+    public void beforeMethod() {
+        mocksControl = EasyMock.createControl();
+        reportiumImportClientMock = mocksControl.createMock(ReportiumImportClient.class);
+        tested = new PerfectoWebDriverEventListenerImpl(reportiumImportClientMock);
+    }
+
+    private Capture<Command> expectCommand() {
+        Capture<Command> capture = EasyMock.newCapture();
+        reportiumImportClientMock.command(capture(capture));
+        return capture;
+    }
+
+    private RemoteWebElement newRemoteWebElement(String id) {
+        RemoteWebElement element = new RemoteWebElement();
+        element.setId(id);
+        return element;
+    }
+
+    private void assertNoParameters(Command command) {
+        assertTrue(command.getParameters().isEmpty());
+    }
+
+    private void assertSingleParameter(Command command, String name, String value) {
+        assertEquals(command.getParameters(), Arrays.asList(new CommandParameter(name, value)));
+    }
+
+    // ---------------------------------------------------------------- alerts
+
+    @Test
+    public void alertAccept() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeAlertAccept(null);
+        tested.afterAlertAccept(null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "AlertAccept");
+        assertEquals(command.getStatus(), CommandStatus.SUCCESS);
+        assertNoParameters(command);
+    }
+
+    @Test
+    public void alertDismiss() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeAlertDismiss(null);
+        tested.afterAlertDismiss(null);
+
+        mocksControl.verify();
+        assertEquals(capture.getValue().getName(), "AlertDismiss");
+    }
+
+    // ------------------------------------------------------------ navigation
+
+    @Test
+    public void navigateTo() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeNavigateTo("http://example.com", null);
+        tested.afterNavigateTo("http://example.com", null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "NavigateTo");
+        assertSingleParameter(command, "url", "http://example.com");
+    }
+
+    @Test
+    public void navigateBack() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeNavigateBack(null);
+        tested.afterNavigateBack(null);
+
+        mocksControl.verify();
+        assertEquals(capture.getValue().getName(), "NavigateBack");
+    }
+
+    @Test
+    public void navigateForward() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeNavigateForward(null);
+        tested.afterNavigateForward(null);
+
+        mocksControl.verify();
+        assertEquals(capture.getValue().getName(), "NavigateForward");
+    }
+
+    @Test
+    public void navigateRefresh() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeNavigateRefresh(null);
+        tested.afterNavigateRefresh(null);
+
+        mocksControl.verify();
+        assertEquals(capture.getValue().getName(), "NavigateRefresh");
+    }
+
+    // ----------------------------------------------------------------- findBy
+
+    @Test
+    public void findBy() {
+        By by = By.id("someId");
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeFindBy(by, null, null);
+        tested.afterFindBy(by, null, null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "FindBy");
+        assertSingleParameter(command, "by", by.toString());
+    }
+
+    // ---------------------------------------------------------------- clickOn
+
+    @Test
+    public void clickOn_withElement() {
+        RemoteWebElement element = newRemoteWebElement("elementId");
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeClickOn(element, null);
+        tested.afterClickOn(element, null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "ClickOn");
+        assertSingleParameter(command, "element", element.toString());
+    }
+
+    @Test
+    public void clickOn_nullElement() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeClickOn(null, null);
+        tested.afterClickOn(null, null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "ClickOn");
+        assertNoParameters(command);
+    }
+
+    // ---------------------------------------------------------- changeValueOf
+
+    @Test
+    public void changeValueOf_nullElement_nullKeys() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeChangeValueOf(null, null, null);
+        tested.afterChangeValueOf(null, null, null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "ChangeValueOf");
+        assertNoParameters(command);
+    }
+
+    @Test
+    public void changeValueOf_withElement_withKeys() {
+        RemoteWebElement element = newRemoteWebElement("elementId");
+        CharSequence[] keys = new CharSequence[]{"x", "y"};
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeChangeValueOf(element, null, keys);
+        tested.afterChangeValueOf(element, null, keys);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "ChangeValueOf");
+        assertEquals(command.getParameters(), Arrays.asList(
+                new CommandParameter("element", element.toString()),
+                new CommandParameter("keys", "x, y")));
+    }
+
+    @Test
+    public void changeValueOf_withElement_emptyKeys() {
+        RemoteWebElement element = newRemoteWebElement("elementId");
+        CharSequence[] keys = new CharSequence[0];
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeChangeValueOf(element, null, keys);
+        tested.afterChangeValueOf(element, null, keys);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertSingleParameter(command, "element", element.toString());
+    }
+
+    // --------------------------------------------------------------- script
+
+    @Test
+    public void script() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeScript("alert('hi')", null);
+        tested.afterScript("alert('hi')", null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "Script");
+        assertSingleParameter(command, "script", "alert('hi')");
+    }
+
+    // ----------------------------------------------------------- switchWindow
+
+    @Test
+    public void switchToWindow() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeSwitchToWindow("myWindow", null);
+        tested.afterSwitchToWindow("myWindow", null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "SwitchToWindow");
+        assertSingleParameter(command, "windowName", "myWindow");
+    }
+
+    // -------------------------------------------------------------- sendKeys
+
+    @Test
+    public void sendKeys_withKeys() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeSendKeys("a", "b");
+        tested.afterSendKeys("a", "b");
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "SendKeys");
+        assertSingleParameter(command, "keys", "a, b");
+    }
+
+    @Test
+    public void sendKeys_nullArray() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeSendKeys((CharSequence[]) null);
+        tested.afterSendKeys((CharSequence[]) null);
+
+        mocksControl.verify();
+        assertNoParameters(capture.getValue());
+    }
+
+    @Test
+    public void sendKeys_emptyArray() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeSendKeys();
+        tested.afterSendKeys();
+
+        mocksControl.verify();
+        assertNoParameters(capture.getValue());
+    }
+
+    // -------------------------------------------------------------- pressKey
+
+    @Test
+    public void pressKey_withKey() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforePressKey("a");
+        tested.afterPressKey("a");
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "PressKey");
+        assertSingleParameter(command, "key", "a");
+    }
+
+    @Test
+    public void pressKey_nullKey() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforePressKey(null);
+        tested.afterPressKey(null);
+
+        mocksControl.verify();
+        assertNoParameters(capture.getValue());
+    }
+
+    // ------------------------------------------------------------ releaseKey
+
+    @Test
+    public void releaseKey_withKey() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeReleaseKey("a");
+        tested.afterReleaseKey("a");
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "ReleaseKey");
+        assertSingleParameter(command, "key", "a");
+    }
+
+    @Test
+    public void releaseKey_nullKey() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeReleaseKey(null);
+        tested.afterReleaseKey(null);
+
+        mocksControl.verify();
+        assertNoParameters(capture.getValue());
+    }
+
+    // ---------------------------------------------------------------- getText
+
+    @Test
+    public void getText_before() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeGetText(null, null);
+        tested.afterGetText(null, null, null);
+
+        mocksControl.verify();
+        assertEquals(capture.getValue().getName(), "GetText");
+    }
+
+    @Test
+    public void getText_after_withText() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeGetText(null, null);
+        tested.afterGetText(null, null, "hello");
+
+        mocksControl.verify();
+        assertSingleParameter(capture.getValue(), "text", "hello");
+    }
+
+    @Test
+    public void getText_after_nullText() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeGetText(null, null);
+        tested.afterGetText(null, null, null);
+
+        mocksControl.verify();
+        assertNoParameters(capture.getValue());
+    }
+
+    // ------------------------------------------------------------------ click
+
+    @Test
+    public void click_nullCoordinates() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeClick(null);
+        tested.afterClick(null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "Click");
+        assertNoParameters(command);
+    }
+
+    @Test
+    public void click_withRemoteWebElementCoordinates() {
+        RemoteWebElement element = newRemoteWebElement("elementId");
+        Coordinates coordinates = element.getCoordinates();
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeClick(coordinates);
+        tested.afterClick(coordinates);
+
+        mocksControl.verify();
+        assertSingleParameter(capture.getValue(), "coordinates", element.toString());
+    }
+
+    @Test
+    public void click_withNonRemoteWebElementCoordinates() {
+        Coordinates coordinates = new NonRemoteElementCoordinates();
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeClick(coordinates);
+        tested.afterClick(coordinates);
+
+        mocksControl.verify();
+        assertNoParameters(capture.getValue());
+    }
+
+    @Test
+    public void click_withCoordinatesReflectionFailure() {
+        Coordinates coordinates = mocksControl.createMock(Coordinates.class);
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeClick(coordinates);
+        tested.afterClick(coordinates);
+
+        mocksControl.verify();
+        // Reflection failed to find "this$0" on the mock; parameter extraction is swallowed.
+        assertNoParameters(capture.getValue());
+    }
+
+    // ------------------------------------------------------------ doubleClick
+
+    @Test
+    public void doubleClick() {
+        RemoteWebElement element = newRemoteWebElement("elementId");
+        Coordinates coordinates = element.getCoordinates();
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeDoubleClick(coordinates);
+        tested.afterDoubleClick(coordinates);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "DoubleClick");
+        assertSingleParameter(command, "coordinates", element.toString());
+    }
+
+    // -------------------------------------------------------------- mouseDown
+
+    @Test
+    public void mouseDown() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeMouseDown();
+        tested.afterMouseDown();
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "MouseDown");
+        assertNoParameters(command);
+    }
+
+    // ---------------------------------------------------------------- mouseUp
+
+    @Test
+    public void mouseUp() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeMouseUp(null);
+        tested.afterMouseUp(null);
+
+        mocksControl.verify();
+        assertEquals(capture.getValue().getName(), "MouseUp");
+    }
+
+    // -------------------------------------------------------------- mouseMove
+
+    @Test
+    public void mouseMove_withoutOffsets() {
+        RemoteWebElement element = newRemoteWebElement("elementId");
+        Coordinates coordinates = element.getCoordinates();
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeMouseMove(coordinates);
+        tested.afterMouseMove(coordinates);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "MouseMove");
+        assertSingleParameter(command, "coordinates", element.toString());
+    }
+
+    @Test
+    public void mouseMove_withOffsets() {
+        RemoteWebElement element = newRemoteWebElement("elementId");
+        Coordinates coordinates = element.getCoordinates();
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeMouseMove(coordinates, 5L, 10L);
+        tested.afterMouseMove(coordinates, 5L, 10L);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "MouseMove");
+        assertEquals(command.getParameters(), Arrays.asList(
+                new CommandParameter("coordinates", element.toString()),
+                new CommandParameter("xOffset", "5"),
+                new CommandParameter("yOffset", "10")));
+    }
+
+    // ----------------------------------------------------------- contextClick
+
+    @Test
+    public void contextClick() {
+        RemoteWebElement element = newRemoteWebElement("elementId");
+        Coordinates coordinates = element.getCoordinates();
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeContextClick(coordinates);
+        tested.afterContextClick(coordinates);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getName(), "ContextClick");
+        assertSingleParameter(command, "coordinates", element.toString());
+    }
+
+    // -------------------------------------------------------------- screenshot
+
+    @Test
+    public void getScreenshotAs_before() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeGetScreenshotAs(OutputType.BYTES);
+        tested.afterGetScreenshotAs(OutputType.BYTES, new byte[]{1, 2, 3});
+
+        mocksControl.verify();
+        assertEquals(capture.getValue().getName(), "Screenshot");
+    }
+
+    @Test
+    public void getScreenshotAs_withFile() throws Exception {
+        Path tempFile = Files.createTempFile("screenshot_", ".png");
+        tempFile.toFile().deleteOnExit();
+        try {
+            Capture<Command> capture = expectCommand();
+            mocksControl.replay();
+
+            tested.beforeGetScreenshotAs(OutputType.FILE);
+            tested.afterGetScreenshotAs(OutputType.FILE, tempFile.toFile());
+
+            mocksControl.verify();
+            Command command = capture.getValue();
+            assertEquals(command.getScreenshots().size(), 1);
+            assertEquals(command.getScreenshots().get(0).getAbsolutePath(), tempFile.toFile().getAbsolutePath());
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    public void getScreenshotAs_withByteArray() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeGetScreenshotAs(OutputType.BYTES);
+        tested.afterGetScreenshotAs(OutputType.BYTES, "not-a-real-png".getBytes(StandardCharsets.UTF_8));
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getScreenshots().size(), 1);
+        assertEquals(command.getScreenshots().get(0).getExtension(), "png");
+    }
+
+    @Test
+    public void getScreenshotAs_withBase64String() {
+        String base64 = Base64.encodeBase64String("not-a-real-png".getBytes(StandardCharsets.UTF_8));
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeGetScreenshotAs(OutputType.BASE64);
+        tested.afterGetScreenshotAs(OutputType.BASE64, base64);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getScreenshots().size(), 1);
+        assertEquals(command.getScreenshots().get(0).getExtension(), "png");
+    }
+
+    @Test
+    public void getScreenshotAs_withUnsupportedType() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeGetScreenshotAs(OutputType.BYTES);
+        invokeAfterGetScreenshotAsRaw(OutputType.BYTES, null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertTrue(command.getScreenshots().isEmpty());
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void invokeAfterGetScreenshotAsRaw(OutputType target, Object screenshot) {
+        tested.afterGetScreenshotAs(target, screenshot);
+    }
+
+    @Test
+    public void getScreenshotAs_afterWithoutBefore_doesNotSendCommand() {
+        mocksControl.replay();
+
+        tested.afterGetScreenshotAs(OutputType.BYTES, new byte[]{1});
+
+        mocksControl.verify();
+    }
+
+    // ------------------------------------------------------------- onException
+
+    @Test
+    public void onException_withPendingCommand() {
+        Capture<Command> capture = expectCommand();
+        mocksControl.replay();
+
+        tested.beforeClickOn(null, null);
+        tested.onException(new RuntimeException("boom"), null);
+
+        mocksControl.verify();
+        Command command = capture.getValue();
+        assertEquals(command.getStatus(), CommandStatus.FAILURE);
+        assertEquals(command.getMessage(), "boom");
+    }
+
+    @Test
+    public void onException_withoutPendingCommand() {
+        mocksControl.replay();
+
+        tested.onException(new RuntimeException("boom"), null);
+
+        mocksControl.verify();
+    }
+
+    // ------------------------------------------------------------------ onQuit
+
+    @Test
+    public void onQuit() {
+        reportiumImportClientMock.quit();
+        mocksControl.replay();
+
+        tested.onQuit();
+
+        mocksControl.verify();
+    }
+
+    // --------------------------------------------------------- generic after()
+
+    @Test
+    public void afterWithoutBefore_doesNotSendCommand() {
+        mocksControl.replay();
+
+        tested.afterAlertAccept(null);
+
+        mocksControl.verify();
+    }
+}

--- a/reportium-java/src/test/java/com/perfecto/reportium/client/LoggerReportiumClientTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/client/LoggerReportiumClientTest.java
@@ -1,0 +1,115 @@
+package com.perfecto.reportium.client;
+
+import com.perfecto.reportium.test.TestContext;
+import com.perfecto.reportium.test.result.TestResultFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test case for {@link LoggerReportiumClient}
+ */
+public class LoggerReportiumClientTest {
+
+    private static final class CapturingHandler extends Handler {
+        private LogRecord lastRecord;
+
+        @Override
+        public void publish(LogRecord record) {
+            lastRecord = record;
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        String getLastMessage() {
+            return lastRecord == null ? null : lastRecord.getMessage();
+        }
+    }
+
+    private final LoggerReportiumClient client = new LoggerReportiumClient();
+    private final Logger logger = Logger.getLogger("ReportiumLogger");
+    private CapturingHandler handler;
+
+    @BeforeMethod
+    public void setup() {
+        handler = new CapturingHandler();
+        logger.setLevel(Level.ALL);
+        logger.addHandler(handler);
+    }
+
+    @AfterMethod
+    public void teardown() {
+        logger.removeHandler(handler);
+    }
+
+    @Test
+    public void testTestStart() {
+        client.testStart("myTest", new TestContext("tag1"));
+        assertTrue(handler.getLastMessage().contains("Starting test - myTest"));
+        assertTrue(handler.getLastMessage().contains("tag1"));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testTestStep() {
+        client.testStep("step description");
+        assertEquals(handler.getLastMessage(), "Executing step - step description");
+    }
+
+    @Test
+    public void testStepStart() {
+        client.stepStart("step description");
+        assertEquals(handler.getLastMessage(), "Starting step - step description");
+    }
+
+    @Test
+    public void testStepEnd() {
+        client.stepEnd();
+        assertEquals(handler.getLastMessage(), "Ending step");
+    }
+
+    @Test
+    public void testStepEndWithMessage() {
+        client.stepEnd("done");
+        assertEquals(handler.getLastMessage(), "Ending step - done");
+    }
+
+    @Test
+    public void testReportiumAssert() {
+        client.reportiumAssert("assertion message", true);
+        assertTrue(handler.getLastMessage().contains("assertion message"));
+        assertTrue(handler.getLastMessage().contains("true"));
+    }
+
+    @Test
+    public void testTestStop() {
+        client.testStop(TestResultFactory.createSuccess());
+        assertTrue(handler.getLastMessage().startsWith("Test result:"));
+    }
+
+    @Test
+    public void testTestStopWithContext() {
+        client.testStop(TestResultFactory.createSuccess(), new TestContext("tag1"));
+        assertTrue(handler.getLastMessage().startsWith("Test result:"));
+        assertTrue(handler.getLastMessage().contains("with test context"));
+    }
+
+    @Test
+    public void testGetReportUrl() {
+        assertEquals(client.getReportUrl(), "N/A - local logger");
+    }
+}

--- a/reportium-java/src/test/java/com/perfecto/reportium/client/PerfectoReportiumClientTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/client/PerfectoReportiumClientTest.java
@@ -1,19 +1,25 @@
 package com.perfecto.reportium.client;
 
 import com.perfecto.reportium.exception.ReportiumException;
+import com.perfecto.reportium.model.CustomField;
+import com.perfecto.reportium.model.Job;
 import com.perfecto.reportium.model.PerfectoExecutionContext;
+import com.perfecto.reportium.model.Project;
 import com.perfecto.reportium.test.TestContext;
 import com.perfecto.reportium.test.result.TestResultFactory;
+import org.easymock.Capture;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.easymock.EasyMock.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Test case for {@link PerfectoReportiumClient}
@@ -26,6 +32,12 @@ public class PerfectoReportiumClientTest {
      * Marker interface for EasyMock to simulate a RemoteWebDriver.
      */
     private interface DriverWithCapabilities extends WebDriver, HasCapabilities, JavascriptExecutor {
+    }
+
+    /**
+     * Marker interface for a WebDriver instance that does NOT expose Selenium Capabilities.
+     */
+    private interface PlainWebDriver extends WebDriver {
     }
 
     @SuppressWarnings("deprecation")
@@ -75,7 +87,7 @@ public class PerfectoReportiumClientTest {
     public void testRequiredWebDriver() {
         new PerfectoExecutionContext.PerfectoExecutionContextBuilder().build();
     }
-    
+
     @Test
     public void testGetReportUrl_WithQueryParameters() {
         DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
@@ -96,4 +108,264 @@ public class PerfectoReportiumClientTest {
         verify(webDriverMock, capabilitiesMock);
     }
 
+    @Test
+    public void testGetReportUrl_NotHasCapabilities() {
+        PlainWebDriver webDriverMock = createMock(PlainWebDriver.class);
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+
+        replay(webDriverMock);
+
+        try {
+            client.getReportUrl();
+            org.testng.Assert.fail("Expected a ReportiumException");
+        } catch (ReportiumException e) {
+            assertEquals(e.getMessage(), "WebDriver instance is assumed to have Selenium Capabilities");
+        }
+
+        verify(webDriverMock);
+    }
+
+    @Test
+    public void testGetReportUrl_NullCapabilityValue() {
+        DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+        Capabilities capabilitiesMock = createMock(Capabilities.class);
+
+        expect(webDriverMock.getCapabilities()).andReturn(capabilitiesMock);
+        expect(capabilitiesMock.getCapability(eq(Constants.Capabilities.executionReportUrl))).andReturn(null);
+
+        replay(webDriverMock, capabilitiesMock);
+
+        assertEquals(client.getReportUrl(), null);
+
+        verify(webDriverMock, capabilitiesMock);
+    }
+
+    @Test
+    public void testGetReportUrl_InvalidUriFallsBackToRawValue() {
+        DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+        Capabilities capabilitiesMock = createMock(Capabilities.class);
+
+        String invalidUri = "https://tenant.reporting.perfectomobile.com/library?param=a b|c";
+        expect(webDriverMock.getCapabilities()).andReturn(capabilitiesMock);
+        expect(capabilitiesMock.getCapability(eq(Constants.Capabilities.executionReportUrl))).andReturn(invalidUri);
+
+        replay(webDriverMock, capabilitiesMock);
+
+        assertEquals(client.getReportUrl(), invalidUri);
+
+        verify(webDriverMock, capabilitiesMock);
+    }
+
+    @Test
+    public void testTestStart_withJobAndProject() {
+        DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
+        Capture<Map<String, Object>> paramsCapture = newCapture();
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .withJob(new Job("myJob", 42).withBranch("myBranch"))
+                .withProject(new Project("myProject", "1.0"))
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+
+        expect(webDriverMock.executeScript(eq("mobile:test:start"), capture(paramsCapture))).andReturn(1000);
+        replay(webDriverMock);
+
+        client.testStart("abc", new TestContext());
+
+        Map<String, Object> params = paramsCapture.getValue();
+        assertEquals(params.get("jobName"), "myJob");
+        assertEquals(params.get("jobNumber"), 42);
+        assertEquals(params.get("jobBranch"), "myBranch");
+        assertEquals(params.get("projectName"), "myProject");
+        assertEquals(params.get("projectVersion"), "1.0");
+
+        verify(webDriverMock);
+    }
+
+    @Test
+    public void testTestStart_withCustomFieldsFromBothContexts() {
+        DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
+        Capture<Map<String, Object>> paramsCapture = newCapture();
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .withCustomFields(new CustomField("shared", "fromExecutionContext"))
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+
+        expect(webDriverMock.executeScript(eq("mobile:test:start"), capture(paramsCapture))).andReturn(1000);
+        replay(webDriverMock);
+
+        TestContext testContext = new TestContext.Builder()
+                .withCustomFields(new CustomField("shared", "fromTestContext"), new CustomField("onlyTest", "v"))
+                .build();
+        client.testStart("abc", testContext);
+
+        @SuppressWarnings("unchecked")
+        java.util.List<String> customFieldsPairs = (java.util.List<String>) paramsCapture.getValue().get("customFields");
+        // The context custom field "shared" wins over the execution-context one because it's added first
+        assertTrue(customFieldsPairs.contains("shared=fromTestContext"));
+        assertTrue(customFieldsPairs.contains("onlyTest=v"));
+        // The duplicate "shared" name from the execution context must not be added twice
+        assertEquals(customFieldsPairs.size(), 2);
+
+        verify(webDriverMock);
+    }
+
+    @Test(expectedExceptions = ReportiumException.class,
+            expectedExceptionsMessageRegExp = "Custom field name cannot be empty")
+    public void testTestStart_blankCustomFieldNameThrows() {
+        DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+        replay(webDriverMock);
+
+        TestContext testContext = new TestContext.Builder()
+                .withCustomFields(new CustomField("", "v"))
+                .build();
+        client.testStart("abc", testContext);
+    }
+
+    @Test
+    public void testStepStart() {
+        DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+
+        Capture<Map<String, Object>> paramsCapture = newCapture();
+        expect(webDriverMock.executeScript(eq("mobile:step:start"), capture(paramsCapture))).andReturn(1);
+        replay(webDriverMock);
+
+        client.stepStart("my step");
+
+        assertEquals(paramsCapture.getValue().get("name"), "my step");
+        verify(webDriverMock);
+    }
+
+    @Test
+    public void testStepEnd_noMessage() {
+        DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+
+        Capture<Map<String, Object>> paramsCapture = newCapture();
+        expect(webDriverMock.executeScript(eq("mobile:step:end"), capture(paramsCapture))).andReturn(1);
+        replay(webDriverMock);
+
+        client.stepEnd();
+
+        assertEquals(paramsCapture.getValue().get("message"), null);
+        verify(webDriverMock);
+    }
+
+    @Test
+    public void testStepEnd_withMessage() {
+        DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+
+        Capture<Map<String, Object>> paramsCapture = newCapture();
+        expect(webDriverMock.executeScript(eq("mobile:step:end"), capture(paramsCapture))).andReturn(1);
+        replay(webDriverMock);
+
+        client.stepEnd("done");
+
+        assertEquals(paramsCapture.getValue().get("message"), "done");
+        verify(webDriverMock);
+    }
+
+    @Test
+    public void testReportiumAssert() {
+        DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+
+        Capture<Map<String, Object>> paramsCapture = newCapture();
+        expect(webDriverMock.executeScript(eq("mobile:status:assert"), capture(paramsCapture))).andReturn(1);
+        replay(webDriverMock);
+
+        client.reportiumAssert("my message", true);
+
+        assertEquals(paramsCapture.getValue().get("message"), "my message");
+        assertEquals(paramsCapture.getValue().get("status"), true);
+        verify(webDriverMock);
+    }
+
+    @Test
+    public void testTestStop_withTagsAndCustomFieldsInTestContext() {
+        DriverWithCapabilities webDriverMock = createMock(DriverWithCapabilities.class);
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+        PerfectoReportiumClient client = new PerfectoReportiumClient(context);
+
+        Capture<Map<String, Object>> paramsCapture = newCapture();
+        expect(webDriverMock.executeScript(eq("mobile:test:end"), capture(paramsCapture))).andReturn(1);
+        replay(webDriverMock);
+
+        TestContext testContext = new TestContext.Builder()
+                .withTestExecutionTags("tag1")
+                .withCustomFields(new CustomField("name1", "value1"))
+                .build();
+        client.testStop(TestResultFactory.createSuccess(), testContext);
+
+        Map<String, Object> params = paramsCapture.getValue();
+        assertEquals(params.get("success"), true);
+        assertTrue(((java.util.List<?>) params.get("tags")).contains("tag1"));
+        assertTrue(((java.util.List<?>) params.get("customFields")).contains("name1=value1"));
+
+        verify(webDriverMock);
+    }
+
+    @Test
+    public void testConstructor_reportsMultipleExecutions() {
+        DriverWithCapabilities webDriverMock1 = createMock(DriverWithCapabilities.class);
+        DriverWithCapabilities webDriverMock2 = createMock(DriverWithCapabilities.class);
+        Capabilities capabilities1 = createMock(Capabilities.class);
+        Capabilities capabilities2 = createMock(Capabilities.class);
+
+        expect(webDriverMock1.getCapabilities()).andReturn(capabilities1);
+        expect(capabilities1.getCapability(eq(Constants.Capabilities.executionId))).andReturn("ext-1");
+        expect(webDriverMock2.getCapabilities()).andReturn(capabilities2);
+        expect(capabilities2.getCapability(eq(Constants.Capabilities.executionId))).andReturn("ext-2");
+
+        Capture<Map<String, Object>> paramsCapture = newCapture();
+        expect(webDriverMock1.executeScript(eq("mobile:execution:multiple"), capture(paramsCapture))).andReturn(1);
+
+        replay(webDriverMock1, webDriverMock2, capabilities1, capabilities2);
+
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock1, "  alias!! 1  ")
+                .withWebDriver(webDriverMock2, "alias 2")
+                .build();
+        new PerfectoReportiumClient(context);
+
+        String json = (String) paramsCapture.getValue().get("externalIdAliases");
+        assertTrue(json.contains("\"externalId\":\"ext-1\""));
+        assertTrue(json.contains("\"alias\":\"alias 1\""));
+        assertTrue(json.contains("\"externalId\":\"ext-2\""));
+        assertTrue(json.contains("\"alias\":\"alias 2\""));
+
+        verify(webDriverMock1, webDriverMock2, capabilities1, capabilities2);
+    }
 }

--- a/reportium-java/src/test/java/com/perfecto/reportium/client/PerfectoTestResultVisitorTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/client/PerfectoTestResultVisitorTest.java
@@ -1,0 +1,55 @@
+package com.perfecto.reportium.client;
+
+import com.perfecto.reportium.test.result.TestResultFactory;
+import com.perfecto.reportium.test.result.TestResultFailure;
+import com.perfecto.reportium.test.result.TestResultSuccess;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test case for {@link PerfectoTestResultVisitor}
+ */
+public class PerfectoTestResultVisitorTest {
+
+    @Test
+    public void testVisitSuccess() {
+        Map<String, Object> params = new HashMap<>();
+        PerfectoTestResultVisitor visitor = new PerfectoTestResultVisitor(params);
+
+        visitor.visit((TestResultSuccess) TestResultFactory.createSuccess());
+
+        assertEquals(params.get("success"), true);
+    }
+
+    @Test
+    public void testVisitFailureWithFailureReason() {
+        Map<String, Object> params = new HashMap<>();
+        PerfectoTestResultVisitor visitor = new PerfectoTestResultVisitor(params);
+        TestResultFailure failure = (TestResultFailure) TestResultFactory.createFailure("boom", null, "myReason");
+
+        visitor.visit(failure);
+
+        assertEquals(params.get("success"), false);
+        assertEquals(params.get("failureDescription"), "boom");
+        assertEquals(params.get("failureReason"), "myReason");
+    }
+
+    @Test
+    public void testVisitFailureWithoutFailureReason() {
+        Map<String, Object> params = new HashMap<>();
+        PerfectoTestResultVisitor visitor = new PerfectoTestResultVisitor(params);
+        TestResultFailure failure = (TestResultFailure) TestResultFactory.createFailure("boom", null, "   ");
+
+        visitor.visit(failure);
+
+        assertEquals(params.get("success"), false);
+        assertEquals(params.get("failureDescription"), "boom");
+        assertFalse(params.containsKey("failureReason"));
+    }
+}

--- a/reportium-java/src/test/java/com/perfecto/reportium/client/ReportiumClientFactoryTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/client/ReportiumClientFactoryTest.java
@@ -1,0 +1,36 @@
+package com.perfecto.reportium.client;
+
+import com.perfecto.reportium.model.PerfectoExecutionContext;
+import org.easymock.EasyMock;
+import org.openqa.selenium.WebDriver;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test case for {@link ReportiumClientFactory}
+ */
+public class ReportiumClientFactoryTest {
+
+    private final ReportiumClientFactory factory = new ReportiumClientFactory();
+
+    @Test
+    public void testCreatePerfectoReportiumClient() {
+        WebDriver webDriverMock = EasyMock.createNiceMock(WebDriver.class);
+        PerfectoExecutionContext context = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+
+        ReportiumClient client = factory.createPerfectoReportiumClient(context);
+        assertNotNull(client);
+        assertTrue(client instanceof PerfectoReportiumClient);
+    }
+
+    @Test
+    public void testCreateLoggerClient() {
+        ReportiumClient client = factory.createLoggerClient();
+        assertNotNull(client);
+        assertTrue(client instanceof LoggerReportiumClient);
+    }
+}

--- a/reportium-java/src/test/java/com/perfecto/reportium/client/ReportiumClientProviderTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/client/ReportiumClientProviderTest.java
@@ -3,6 +3,8 @@ package com.perfecto.reportium.client;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Field;
+
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
@@ -20,10 +22,12 @@ public class ReportiumClientProviderTest {
     }
 
     @AfterMethod
-    public void teardown() {
-        // Clear thread local state left over from tests, since it is stored in a static ThreadLocal
-        DigitalZoomClient client = createMock(DigitalZoomClient.class);
-        ReportiumClientProvider.set(client);
+    public void teardown() throws Exception {
+        // ReportiumClientProvider only exposes get()/set(), so the ThreadLocal it backs must be
+        // reset via reflection to avoid leaking state into other tests on this thread.
+        Field field = ReportiumClientProvider.class.getDeclaredField("reportiumClient");
+        field.setAccessible(true);
+        ((ThreadLocal<?>) field.get(null)).remove();
     }
 
     @Test

--- a/reportium-java/src/test/java/com/perfecto/reportium/client/ReportiumClientProviderTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/client/ReportiumClientProviderTest.java
@@ -1,0 +1,60 @@
+package com.perfecto.reportium.client;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.easymock.EasyMock.createMock;
+
+/**
+ * Test case for {@link ReportiumClientProvider}
+ */
+public class ReportiumClientProviderTest {
+
+    @Test
+    public void testConstructorIsAccessible() {
+        // Exercises the implicit default constructor
+        assertNotNull(new ReportiumClientProvider());
+    }
+
+    @AfterMethod
+    public void teardown() {
+        // Clear thread local state left over from tests, since it is stored in a static ThreadLocal
+        DigitalZoomClient client = createMock(DigitalZoomClient.class);
+        ReportiumClientProvider.set(client);
+    }
+
+    @Test
+    public void testSetAndGet() {
+        DigitalZoomClient client = createMock(DigitalZoomClient.class);
+        ReportiumClientProvider.set(client);
+        assertSame(ReportiumClientProvider.get(), client);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "digitalZoomClient cannot be null")
+    public void testSetNull() {
+        ReportiumClientProvider.set(null);
+    }
+
+    @Test
+    public void testGetWithoutSet() {
+        // A brand new thread has no value bound to the ThreadLocal
+        final DigitalZoomClient[] result = new DigitalZoomClient[1];
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                result[0] = ReportiumClientProvider.get();
+            }
+        });
+        thread.start();
+        try {
+            thread.join();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        assertNull(result[0]);
+    }
+}

--- a/reportium-java/src/test/java/com/perfecto/reportium/model/BaseExecutionContextTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/model/BaseExecutionContextTest.java
@@ -1,0 +1,112 @@
+package com.perfecto.reportium.model;
+
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test case for {@link BaseExecutionContext} and its {@link BaseExecutionContext.Builder}.
+ * <p>
+ * {@link BaseExecutionContext.Builder} is protected, so it is exercised here directly (same package)
+ * to cover the branches that aren't reachable through the public {@link PerfectoExecutionContext} subclass,
+ * such as the collection-typed with* overloads and the copy constructor.
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class BaseExecutionContextTest {
+
+    @Test
+    public void testPlainBuild() {
+        BaseExecutionContext.Builder builder = new BaseExecutionContext.Builder();
+        BaseExecutionContext context = builder.build();
+        assertNotNull(context);
+        assertEquals(context.getContextTags().size(), 0);
+        assertEquals(context.getCustomFields().size(), 0);
+    }
+
+    @Test
+    public void testWithContextTags_collectionNull() {
+        BaseExecutionContext.Builder builder = new BaseExecutionContext.Builder();
+        builder.withContextTags((java.util.Collection<String>) null);
+        BaseExecutionContext context = builder.build();
+        assertEquals(context.getContextTags().size(), 0);
+    }
+
+    @Test
+    public void testWithContextTags_collectionEmpty() {
+        BaseExecutionContext.Builder builder = new BaseExecutionContext.Builder();
+        builder.withContextTags(Collections.<String>emptyList());
+        BaseExecutionContext context = builder.build();
+        assertEquals(context.getContextTags().size(), 0);
+    }
+
+    @Test
+    public void testWithContextTags_collectionWithValidTag() {
+        BaseExecutionContext.Builder builder = new BaseExecutionContext.Builder();
+        builder.withContextTags(Arrays.asList("tagA", "tagB"));
+        BaseExecutionContext context = builder.build();
+        assertTrue(context.getContextTags().containsAll(Arrays.asList("tagA", "tagB")));
+    }
+
+    @Test
+    public void testWithContextTags_varargsNull() {
+        BaseExecutionContext.Builder builder = new BaseExecutionContext.Builder();
+        builder.withContextTags((String[]) null);
+        BaseExecutionContext context = builder.build();
+        assertEquals(context.getContextTags().size(), 0);
+    }
+
+    @Test
+    public void testWithCustomFields_collectionNull() {
+        BaseExecutionContext.Builder builder = new BaseExecutionContext.Builder();
+        builder.withCustomFields((java.util.Collection<CustomField>) null);
+        BaseExecutionContext context = builder.build();
+        assertEquals(context.getCustomFields().size(), 0);
+    }
+
+    @Test
+    public void testWithCustomFields_collectionEmpty() {
+        BaseExecutionContext.Builder builder = new BaseExecutionContext.Builder();
+        builder.withCustomFields(Collections.<CustomField>emptyList());
+        BaseExecutionContext context = builder.build();
+        assertEquals(context.getCustomFields().size(), 0);
+    }
+
+    @Test
+    public void testWithCustomFields_collectionWithValidField() {
+        BaseExecutionContext.Builder builder = new BaseExecutionContext.Builder();
+        CustomField field = new CustomField("name", "value");
+        builder.withCustomFields(Arrays.asList(field));
+        BaseExecutionContext context = builder.build();
+        assertTrue(context.getCustomFields().contains(field));
+    }
+
+    @Test
+    public void testWithCustomFields_varargsNull() {
+        BaseExecutionContext.Builder builder = new BaseExecutionContext.Builder();
+        builder.withCustomFields((CustomField[]) null);
+        BaseExecutionContext context = builder.build();
+        assertEquals(context.getCustomFields().size(), 0);
+    }
+
+    @Test
+    public void testCopyConstructor() {
+        BaseExecutionContext.Builder original = new BaseExecutionContext.Builder();
+        original.withJob(new Job("job", 1));
+        original.withProject(new Project("proj", "1.0"));
+        original.withCustomFields(new CustomField("name", "value"));
+        BaseExecutionContext originalContext = original.build();
+
+        BaseExecutionContext.Builder copyBuilder = new BaseExecutionContext.Builder(originalContext);
+        BaseExecutionContext copiedContext = copyBuilder.build();
+
+        assertEquals(copiedContext.getJob().getName(), "job");
+        assertEquals(copiedContext.getProject().getName(), "proj");
+        assertEquals(copiedContext.getCustomFields(), originalContext.getCustomFields());
+        assertEquals(copiedContext.getContextTags(), originalContext.getContextTags());
+    }
+}

--- a/reportium-java/src/test/java/com/perfecto/reportium/model/PerfectoExecutionContextTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/model/PerfectoExecutionContextTest.java
@@ -41,6 +41,17 @@ public class PerfectoExecutionContextTest extends BaseSdkTest {
         assertEquals(0, perfectoExecutionContext.getCustomFields().size());
     }
 
+    @SuppressWarnings("deprecation")
+    @Test
+    public void test_getWebdriverDeprecatedDelegatesToGetWebDriver() {
+        WebDriver webDriverMock = EasyMock.createNiceMock(WebDriver.class);
+        PerfectoExecutionContext perfectoExecutionContext = new PerfectoExecutionContext.PerfectoExecutionContextBuilder()
+                .withWebDriver(webDriverMock)
+                .build();
+
+        assertEquals(perfectoExecutionContext.getWebdriver(), webDriverMock);
+    }
+
     @Test
     public void test_nullContextTags() {
         final String tag = null;

--- a/reportium-java/src/test/java/com/perfecto/reportium/model/util/ListUtilsTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/model/util/ListUtilsTest.java
@@ -50,4 +50,11 @@ public class ListUtilsTest {
         List<String> list2 = null;
         ListUtils.mergeLists(list1, list2);
     }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Arguments cannot be null")
+    public void testMergeWithFirstListNull() {
+        List<String> list1 = null;
+        List<String> list2 = Arrays.asList("123", "456");
+        ListUtils.mergeLists(list1, list2);
+    }
 }

--- a/reportium-java/src/test/java/com/perfecto/reportium/test/TestContextTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/test/TestContextTest.java
@@ -4,6 +4,8 @@ import com.perfecto.reportium.model.CustomField;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -77,5 +79,83 @@ public class TestContextTest {
     public void testNullContextTagsConstructor() {
         TestContext context = new TestContext(null, null, "");
         assertEquals(0, context.getTestExecutionTags().size());
+    }
+
+    @Test
+    public void testNullVarargsArrayConstructor() {
+        TestContext context = new TestContext((String[]) null);
+        assertEquals(0, context.getTestExecutionTags().size());
+    }
+
+    @Test
+    public void testWithTestExecutionTags_varargsNullArray() {
+        TestContext context = new TestContext.Builder()
+                .withTestExecutionTags((String[]) null)
+                .build();
+        assertEquals(0, context.getTestExecutionTags().size());
+    }
+
+    @Test
+    public void testWithCustomFields_varargsNullArray() {
+        TestContext context = new TestContext.Builder()
+                .withCustomFields((CustomField[]) null)
+                .build();
+        assertEquals(0, context.getCustomFields().size());
+    }
+
+    @Test
+    public void testWithTestExecutionTags_collectionNull() {
+        TestContext context = new TestContext.Builder()
+                .withTestExecutionTags((Collection<String>) null)
+                .build();
+        assertEquals(0, context.getTestExecutionTags().size());
+    }
+
+    @Test
+    public void testWithTestExecutionTags_collectionEmpty() {
+        TestContext context = new TestContext.Builder()
+                .withTestExecutionTags(Collections.<String>emptyList())
+                .build();
+        assertEquals(0, context.getTestExecutionTags().size());
+    }
+
+    @Test
+    public void testWithCustomFields_collectionNull() {
+        TestContext context = new TestContext.Builder()
+                .withCustomFields((Collection<CustomField>) null)
+                .build();
+        assertEquals(0, context.getCustomFields().size());
+    }
+
+    @Test
+    public void testWithCustomFields_collectionEmpty() {
+        TestContext context = new TestContext.Builder()
+                .withCustomFields(Collections.<CustomField>emptyList())
+                .build();
+        assertEquals(0, context.getCustomFields().size());
+    }
+
+    @Test
+    public void testCopyConstructor() {
+        TestContext original = new TestContext.Builder()
+                .withTestExecutionTags("tag1")
+                .withCustomFields(new CustomField("name1", "value1"))
+                .build();
+
+        TestContext copy = new TestContext.Builder(original).build();
+
+        assertEquals(copy.getTestExecutionTags(), original.getTestExecutionTags());
+        assertEquals(copy.getCustomFields(), original.getCustomFields());
+    }
+
+    @Test
+    public void testToString() {
+        TestContext context = new TestContext.Builder()
+                .withTestExecutionTags("tag1")
+                .withCustomFields(new CustomField("name1", "value1"))
+                .build();
+        String toString = context.toString();
+        assertTrue(toString.contains("tag1"));
+        assertTrue(toString.contains("name1"));
     }
 }

--- a/reportium-java/src/test/java/com/perfecto/reportium/test/result/TestResultFactoryTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/test/result/TestResultFactoryTest.java
@@ -1,58 +1,75 @@
 package com.perfecto.reportium.test.result;
 
-import org.hamcrest.CoreMatchers;
 import org.testng.annotations.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
- * Created by yurig on 04-May-17.
+ * Test case for {@link TestResultFactory}
  */
 public class TestResultFactoryTest {
+
+    @Test
+    public void testConstructorIsAccessible() {
+        // Exercises the implicit default constructor
+        assertNotNull(new TestResultFactory());
+    }
+
     @Test
     public void testCreateSuccess() {
-        TestResult testResult = TestResultFactory.createSuccess();
-        assertNotNull(testResult);
-        assertTrue(testResult instanceof TestResultSuccess);
+        TestResult result = TestResultFactory.createSuccess();
+        assertTrue(result instanceof TestResultSuccess);
     }
 
     @Test
-    public void testCreateFailure_withoutStackTrace() {
-        String message = "message";
-        TestResult testResult = TestResultFactory.createFailure(message);
-        assertNotNull(testResult);
-        assertTrue(testResult instanceof TestResultFailure);
-        TestResultFailure testResultFailure = (TestResultFailure) testResult;
-        assertEquals(message, testResultFailure.getMessage());
-        assertNull(testResultFailure.getFailureReasonName());
+    public void testCreateFailureWithMessageOnly() {
+        TestResult result = TestResultFactory.createFailure("boom");
+        assertTrue(result instanceof TestResultFailure);
+        TestResultFailure failure = (TestResultFailure) result;
+        assertEquals(failure.getMessage(), "boom");
+        assertNull(failure.getFailureReasonName());
     }
 
     @Test
-    public void testCreateFailure_withStackTrace() {
-        String message = "message";
-        String exceptionMessage = "Exception message";
-        String exceptionType = RuntimeException.class.getSimpleName();
-        TestResult testResult = TestResultFactory.createFailure(message, new RuntimeException(exceptionMessage));
-        assertNotNull(testResult);
-        assertTrue(testResult instanceof TestResultFailure);
-        TestResultFailure testResultFailure = (TestResultFailure) testResult;
-        assertThat(testResultFailure.getMessage(), CoreMatchers.containsString(message));
-        assertThat(testResultFailure.getMessage(), CoreMatchers.containsString(exceptionMessage));
-        assertThat(testResultFailure.getMessage(), CoreMatchers.containsString(exceptionType));
-        assertNull(testResultFailure.getFailureReasonName());
+    public void testCreateFailureWithThrowableOnly() {
+        Throwable throwable = new RuntimeException("boom");
+        TestResult result = TestResultFactory.createFailure(throwable);
+        assertTrue(result instanceof TestResultFailure);
+        TestResultFailure failure = (TestResultFailure) result;
+        assertTrue(failure.getMessage().contains("RuntimeException"));
+        assertNull(failure.getFailureReasonName());
     }
 
     @Test
-    public void testCreateFailure_withStackTraceAndFailureReason() {
-        String message = "message";
-        String exceptionMessage = "Exception message";
-        String failureReason = "failureReason";
-        TestResult testResult = TestResultFactory.createFailure(message, new RuntimeException(exceptionMessage), failureReason);
-        assertNotNull(testResult);
-        assertTrue(testResult instanceof TestResultFailure);
-        TestResultFailure testResultFailure = (TestResultFailure) testResult;
-        assertThat(testResultFailure.getMessage(), CoreMatchers.containsString(exceptionMessage));
-        assertEquals(failureReason, testResultFailure.getFailureReasonName());
+    public void testCreateFailureWithThrowableAndReason() {
+        Throwable throwable = new RuntimeException("boom");
+        TestResult result = TestResultFactory.createFailure(throwable, "myReason");
+        assertTrue(result instanceof TestResultFailure);
+        TestResultFailure failure = (TestResultFailure) result;
+        assertTrue(failure.getMessage().contains("RuntimeException"));
+        assertEquals(failure.getFailureReasonName(), "myReason");
+    }
+
+    @Test
+    public void testCreateFailureWithMessageAndThrowable() {
+        Throwable throwable = new RuntimeException("boom");
+        TestResult result = TestResultFactory.createFailure("custom message", throwable);
+        assertTrue(result instanceof TestResultFailure);
+        TestResultFailure failure = (TestResultFailure) result;
+        assertTrue(failure.getMessage().startsWith("custom message"));
+        assertNull(failure.getFailureReasonName());
+    }
+
+    @Test
+    public void testCreateFailureFull() {
+        Throwable throwable = new RuntimeException("boom");
+        TestResult result = TestResultFactory.createFailure("custom message", throwable, "myReason");
+        assertTrue(result instanceof TestResultFailure);
+        TestResultFailure failure = (TestResultFailure) result;
+        assertTrue(failure.getMessage().startsWith("custom message"));
+        assertEquals(failure.getFailureReasonName(), "myReason");
     }
 }

--- a/reportium-java/src/test/java/com/perfecto/reportium/test/result/TestResultFailureTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/test/result/TestResultFailureTest.java
@@ -6,7 +6,11 @@ import org.testng.annotations.Test;
 
 import static com.perfecto.reportium.test.result.TestResultFailure.MESSAGE_MAX_LENGTH;
 import static com.perfecto.reportium.test.result.TestResultFailure.TRIMMED_TEXT_SUFFIX;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -29,5 +33,49 @@ public class TestResultFailureTest {
         RuntimeException throwable = new RuntimeException("reason");
         TestResultFailure failure = new TestResultFailure(throwable.getMessage(), throwable, null);
         assertEquals(ExceptionUtils.getStackTrace(throwable), failure.getMessage());
+    }
+
+    @Test
+    public void testNoThrowableAndBlankReason() {
+        TestResultFailure failure = new TestResultFailure(null, null, null);
+        assertNull(failure.getMessage());
+    }
+
+    @Test
+    public void testNoThrowableAndBlankReason_emptyString() {
+        TestResultFailure failure = new TestResultFailure("   ", null, null);
+        assertNull(failure.getMessage());
+    }
+
+    @Test
+    public void testNoThrowableWithReasonOnly() {
+        TestResultFailure failure = new TestResultFailure("plain reason", null, null);
+        assertEquals(failure.getMessage(), "plain reason");
+    }
+
+    @Test
+    public void testGetFailureReasonName() {
+        TestResultFailure failure = new TestResultFailure("reason", null, "myFailureReason");
+        assertEquals(failure.getFailureReasonName(), "myFailureReason");
+    }
+
+    @Test
+    public void testToString() {
+        TestResultFailure failure = new TestResultFailure("plain reason", null, "myFailureReason");
+        String toString = failure.toString();
+        assertTrue(toString.contains("plain reason"));
+        assertTrue(toString.contains("myFailureReason"));
+    }
+
+    @Test
+    public void testVisitDispatchesToVisitor() {
+        TestResultFailure failure = new TestResultFailure("plain reason", null, null);
+        TestResultVisitor visitorMock = createMock(TestResultVisitor.class);
+        visitorMock.visit(failure);
+        replay(visitorMock);
+
+        failure.visit(visitorMock);
+
+        verify(visitorMock);
     }
 }

--- a/reportium-java/src/test/java/com/perfecto/reportium/test/result/TestResultSuccessTest.java
+++ b/reportium-java/src/test/java/com/perfecto/reportium/test/result/TestResultSuccessTest.java
@@ -1,0 +1,32 @@
+package com.perfecto.reportium.test.result;
+
+import org.testng.annotations.Test;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test case for {@link TestResultSuccess}
+ */
+public class TestResultSuccessTest {
+
+    @Test
+    public void testVisitDispatchesToVisitor() {
+        TestResultSuccess success = new TestResultSuccess();
+        TestResultVisitor visitorMock = createMock(TestResultVisitor.class);
+        visitorMock.visit(success);
+        replay(visitorMock);
+
+        success.visit(visitorMock);
+
+        verify(visitorMock);
+    }
+
+    @Test
+    public void testToString() {
+        TestResultSuccess success = new TestResultSuccess();
+        assertTrue(success.toString().contains("TestResultSuccess"));
+    }
+}

--- a/reportium-testng/pom.xml
+++ b/reportium-testng/pom.xml
@@ -32,6 +32,13 @@
             <artifactId>selenium-remote-driver</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/reportium-testng/src/test/java/com/perfecto/reportium/testng/BaseReportiumTestNgListenerTest.java
+++ b/reportium-testng/src/test/java/com/perfecto/reportium/testng/BaseReportiumTestNgListenerTest.java
@@ -9,8 +9,10 @@ import com.perfecto.reportium.test.result.TestResultSuccess;
 import org.testng.IClass;
 import org.testng.IInvokedMethod;
 import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Field;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,6 +36,15 @@ public class BaseReportiumTestNgListenerTest {
     private BaseReportiumTestNgListener newListener() {
         return new BaseReportiumTestNgListener() {
         };
+    }
+
+    @AfterMethod
+    public void teardown() throws Exception {
+        // ReportiumClientProvider only exposes get()/set(), so the ThreadLocal it backs must be
+        // reset via reflection to avoid leaking state into other tests on this thread.
+        Field field = ReportiumClientProvider.class.getDeclaredField("reportiumClient");
+        field.setAccessible(true);
+        ((ThreadLocal<?>) field.get(null)).remove();
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/reportium-testng/src/test/java/com/perfecto/reportium/testng/BaseReportiumTestNgListenerTest.java
+++ b/reportium-testng/src/test/java/com/perfecto/reportium/testng/BaseReportiumTestNgListenerTest.java
@@ -1,0 +1,284 @@
+package com.perfecto.reportium.testng;
+
+import com.perfecto.reportium.client.DigitalZoomClient;
+import com.perfecto.reportium.client.ReportiumClientProvider;
+import com.perfecto.reportium.exception.ReportiumException;
+import com.perfecto.reportium.test.TestContext;
+import com.perfecto.reportium.test.result.TestResultFailure;
+import com.perfecto.reportium.test.result.TestResultSuccess;
+import org.testng.IClass;
+import org.testng.IInvokedMethod;
+import org.testng.ITestResult;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.easymock.EasyMock.*;
+import static org.testng.Assert.*;
+
+/**
+ * Unit tests for {@link BaseReportiumTestNgListener}.
+ * <p>
+ * Since the class is abstract but declares no abstract methods, an anonymous subclass with the
+ * default (base) behavior is used to exercise it directly.
+ */
+public class BaseReportiumTestNgListenerTest {
+
+    /** Marker class used only so getRealClass().getSimpleName() has a predictable value. */
+    private static class DummyTestClass {
+    }
+
+    private BaseReportiumTestNgListener newListener() {
+        return new BaseReportiumTestNgListener() {
+        };
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ITestResult mockTestResultWithName(String simpleClassName, String methodName) {
+        IClass testClass = createMock(IClass.class);
+        expect((Class) testClass.getRealClass()).andReturn(DummyTestClass.class).anyTimes();
+        replay(testClass);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getTestClass()).andReturn(testClass).anyTimes();
+        expect(testResult.getName()).andReturn(methodName).anyTimes();
+        return testResult;
+    }
+
+    @Test
+    public void testBeforeInvocation_testMethod_reportsStart() {
+        BaseReportiumTestNgListener listener = newListener();
+
+        IInvokedMethod method = createMock(IInvokedMethod.class);
+        expect(method.isTestMethod()).andReturn(true);
+        replay(method);
+
+        ITestResult testResult = mockTestResultWithName("DummyTestClass", "myTest");
+        replay(testResult);
+
+        DigitalZoomClient client = createMock(DigitalZoomClient.class);
+        client.testStart(eq("DummyTestClass::myTest"), isA(TestContext.class));
+        expectLastCall().once();
+        replay(client);
+        ReportiumClientProvider.set(client);
+
+        listener.beforeInvocation(method, testResult);
+
+        verify(method, testResult, client);
+    }
+
+    @Test
+    public void testBeforeInvocation_nonTestMethod_doesNothing() {
+        BaseReportiumTestNgListener listener = newListener();
+
+        IInvokedMethod method = createMock(IInvokedMethod.class);
+        expect(method.isTestMethod()).andReturn(false);
+        replay(method);
+
+        // No stubs configured: any call on this mock during replay fails the test.
+        ITestResult testResult = createMock(ITestResult.class);
+        replay(testResult);
+
+        listener.beforeInvocation(method, testResult);
+
+        verify(method, testResult);
+    }
+
+    @Test
+    public void testAfterInvocation_nonTestMethod_doesNothing() {
+        BaseReportiumTestNgListener listener = newListener();
+
+        IInvokedMethod method = createMock(IInvokedMethod.class);
+        expect(method.isTestMethod()).andReturn(false);
+        replay(method);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        replay(testResult);
+
+        listener.afterInvocation(method, testResult);
+
+        verify(method, testResult);
+    }
+
+    @Test
+    public void testAfterInvocation_success_reportsSuccess() {
+        assertAfterInvocationReportsResult(ITestResult.SUCCESS, TestResultSuccess.class);
+    }
+
+    @Test
+    public void testAfterInvocation_successPercentageFailure_reportsSuccess() {
+        assertAfterInvocationReportsResult(ITestResult.SUCCESS_PERCENTAGE_FAILURE, TestResultSuccess.class);
+    }
+
+    @Test
+    public void testAfterInvocation_failure_reportsFailure() {
+        BaseReportiumTestNgListener listener = newListener();
+
+        IInvokedMethod method = createMock(IInvokedMethod.class);
+        expect(method.isTestMethod()).andReturn(true);
+        replay(method);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getStatus()).andReturn(ITestResult.FAILURE);
+        expect(testResult.getThrowable()).andReturn(new RuntimeException("boom"));
+        replay(testResult);
+
+        DigitalZoomClient client = createMock(DigitalZoomClient.class);
+        client.testStop(isA(TestResultFailure.class));
+        expectLastCall().once();
+        replay(client);
+        ReportiumClientProvider.set(client);
+
+        listener.afterInvocation(method, testResult);
+
+        verify(method, testResult, client);
+    }
+
+    @Test
+    public void testAfterInvocation_skip_doesNotCallClient() {
+        BaseReportiumTestNgListener listener = newListener();
+
+        IInvokedMethod method = createMock(IInvokedMethod.class);
+        expect(method.isTestMethod()).andReturn(true);
+        replay(method);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getStatus()).andReturn(ITestResult.SKIP);
+        replay(testResult);
+
+        // No expectations configured; any invocation on the client fails the test.
+        DigitalZoomClient client = createMock(DigitalZoomClient.class);
+        replay(client);
+        ReportiumClientProvider.set(client);
+
+        listener.afterInvocation(method, testResult);
+
+        verify(method, testResult, client);
+    }
+
+    @Test
+    public void testAfterInvocation_unexpectedStatus_throwsReportiumException() {
+        BaseReportiumTestNgListener listener = newListener();
+
+        IInvokedMethod method = createMock(IInvokedMethod.class);
+        expect(method.isTestMethod()).andReturn(true);
+        replay(method);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getStatus()).andReturn(ITestResult.STARTED);
+        replay(testResult);
+
+        DigitalZoomClient client = createMock(DigitalZoomClient.class);
+        replay(client);
+        ReportiumClientProvider.set(client);
+
+        try {
+            listener.afterInvocation(method, testResult);
+            fail("Expected a ReportiumException to be thrown");
+        } catch (ReportiumException e) {
+            assertEquals(e.getMessage(), "Unexpected status " + ITestResult.STARTED);
+        }
+
+        verify(method, testResult, client);
+    }
+
+    @Test
+    public void testAfterInvocation_nullClient_doesNothing() throws Exception {
+        // Use a fresh thread so ReportiumClientProvider's ThreadLocal is guaranteed to be unset,
+        // regardless of what other tests in this suite have stored on the current thread.
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Void> future = executor.submit(new Callable<Void>() {
+                @Override
+                public Void call() {
+                    BaseReportiumTestNgListener listener = newListener();
+
+                    IInvokedMethod method = createMock(IInvokedMethod.class);
+                    expect(method.isTestMethod()).andReturn(true);
+                    replay(method);
+
+                    ITestResult testResult = createMock(ITestResult.class);
+                    expect(testResult.getStatus()).andReturn(ITestResult.SUCCESS);
+                    replay(testResult);
+
+                    assertNull(ReportiumClientProvider.get());
+
+                    // Should not throw, even though there is no client to report to.
+                    listener.afterInvocation(method, testResult);
+
+                    verify(method, testResult);
+                    return null;
+                }
+            });
+            future.get();
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void testGetTestName() {
+        ITestResult testResult = mockTestResultWithName("DummyTestClass", "someMethod");
+        replay(testResult);
+
+        BaseReportiumTestNgListener listener = newListener();
+        assertEquals(listener.getTestName(testResult), "DummyTestClass::someMethod");
+
+        verify(testResult);
+    }
+
+    @Test
+    public void testGetJob_defaultsToNull() {
+        BaseReportiumTestNgListener listener = newListener();
+        assertNull(listener.getJob());
+    }
+
+    @Test
+    public void testGetProject_defaultsToNull() {
+        BaseReportiumTestNgListener listener = newListener();
+        assertNull(listener.getProject());
+    }
+
+    @Test
+    public void testGetTags_defaultsToNull() {
+        BaseReportiumTestNgListener listener = newListener();
+        ITestResult testResult = createMock(ITestResult.class);
+        assertNull(listener.getTags(testResult));
+    }
+
+    @Test
+    public void testGetReportiumClient_delegatesToProvider() {
+        DigitalZoomClient client = createMock(DigitalZoomClient.class);
+        replay(client);
+        ReportiumClientProvider.set(client);
+
+        BaseReportiumTestNgListener listener = newListener();
+        assertSame(listener.getReportiumClient(), client);
+    }
+
+    private <T extends com.perfecto.reportium.test.result.TestResult> void assertAfterInvocationReportsResult(
+            int status, Class<T> expectedResultType) {
+        BaseReportiumTestNgListener listener = newListener();
+
+        IInvokedMethod method = createMock(IInvokedMethod.class);
+        expect(method.isTestMethod()).andReturn(true);
+        replay(method);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getStatus()).andReturn(status);
+        replay(testResult);
+
+        DigitalZoomClient client = createMock(DigitalZoomClient.class);
+        client.testStop(isA(expectedResultType));
+        expectLastCall().once();
+        replay(client);
+        ReportiumClientProvider.set(client);
+
+        listener.afterInvocation(method, testResult);
+
+        verify(method, testResult, client);
+    }
+}

--- a/reportium-testng/src/test/java/com/perfecto/reportium/testng/BasicReportiumTestNgListenerTest.java
+++ b/reportium-testng/src/test/java/com/perfecto/reportium/testng/BasicReportiumTestNgListenerTest.java
@@ -1,0 +1,122 @@
+package com.perfecto.reportium.testng;
+
+import com.perfecto.reportium.WebDriverProvider;
+import com.perfecto.reportium.client.ReportiumClient;
+import org.openqa.selenium.HasCapabilities;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.testng.IClass;
+import org.testng.ITestResult;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.easymock.EasyMock.*;
+import static org.testng.Assert.*;
+
+/**
+ * Unit tests for {@link BasicReportiumTestNgListener}.
+ */
+public class BasicReportiumTestNgListenerTest {
+
+    /**
+     * Marker interface for EasyMock to simulate a real Selenium remote driver, which is both
+     * a {@link JavascriptExecutor} (needed by the underlying ReportiumClient) and provides
+     * {@link org.openqa.selenium.Capabilities} (needed for the multiple-execution/report-url checks).
+     */
+    private interface DriverWithCapabilities extends WebDriver, HasCapabilities, JavascriptExecutor {
+    }
+
+    private static class DummyTestClass {
+    }
+
+    private static WebDriverProvider webDriverProviderReturning(final WebDriver driver) {
+        return new WebDriverProvider() {
+            @Override
+            public WebDriver getWebDriver() {
+                return driver;
+            }
+        };
+    }
+
+    @Test
+    public void testGetWebDriver_instanceIsWebDriverProvider_returnsDriver() {
+        WebDriver driverMock = createMock(WebDriver.class);
+        replay(driverMock);
+
+        WebDriverProvider provider = webDriverProviderReturning(driverMock);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getInstance()).andReturn(provider);
+        replay(testResult);
+
+        BasicReportiumTestNgListener listener = new BasicReportiumTestNgListener();
+        assertSame(listener.getWebDriver(testResult), driverMock);
+
+        verify(testResult);
+    }
+
+    @Test
+    public void testGetWebDriver_instanceIsNotWebDriverProvider_throws() {
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getInstance()).andReturn(new Object());
+        replay(testResult);
+
+        BasicReportiumTestNgListener listener = new BasicReportiumTestNgListener();
+        try {
+            listener.getWebDriver(testResult);
+            fail("Expected a RuntimeException to be thrown");
+        } catch (RuntimeException e) {
+            assertEquals(e.getMessage(), "Unable to get WebDriver instance");
+        }
+
+        verify(testResult);
+    }
+
+    @Test
+    public void testCreateReportiumClient_buildsClientFromWebDriver() {
+        DriverWithCapabilities driverMock = createMock(DriverWithCapabilities.class);
+        replay(driverMock);
+
+        WebDriverProvider provider = webDriverProviderReturning(driverMock);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getInstance()).andReturn(provider);
+        replay(testResult);
+
+        BasicReportiumTestNgListener listener = new BasicReportiumTestNgListener();
+        ReportiumClient client = listener.createReportiumClient(testResult);
+
+        assertNotNull(client);
+
+        verify(testResult, driverMock);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testReportTestStart_endToEnd_startsRealClient() {
+        DriverWithCapabilities driverMock = createMock(DriverWithCapabilities.class);
+        expect(driverMock.executeScript(eq("mobile:test:start"), isA(Map.class))).andReturn(1000);
+        replay(driverMock);
+
+        WebDriverProvider provider = webDriverProviderReturning(driverMock);
+
+        IClass testClass = createMock(IClass.class);
+        expect((Class) testClass.getRealClass()).andReturn(DummyTestClass.class).anyTimes();
+        replay(testClass);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getInstance()).andReturn(provider);
+        expect(testResult.getTestClass()).andReturn(testClass).anyTimes();
+        expect(testResult.getName()).andReturn("myTest").anyTimes();
+        replay(testResult);
+
+        BasicReportiumTestNgListener listener = new BasicReportiumTestNgListener();
+        // Exercises BasicReportiumTestNgListener.reportTestStart(), which in turn calls
+        // createReportiumClient(), sets it on the provider, and delegates to the base class,
+        // which calls the real (mocked-webdriver-backed) ReportiumClient.testStart().
+        listener.reportTestStart(testResult);
+
+        verify(testResult, testClass, driverMock);
+    }
+}

--- a/reportium-testng/src/test/java/com/perfecto/reportium/testng/ReportiumImportTestNgListenerTest.java
+++ b/reportium-testng/src/test/java/com/perfecto/reportium/testng/ReportiumImportTestNgListenerTest.java
@@ -1,0 +1,25 @@
+package com.perfecto.reportium.testng;
+
+import org.testng.IInvokedMethodListener;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit test for {@link ReportiumImportTestNgListener}.
+ * <p>
+ * The production class is a trivial one-line marker subclass of {@link BaseReportiumTestNgListener}
+ * with no overridden behavior of its own (all logic is inherited and already covered by
+ * {@link BaseReportiumTestNgListenerTest}). This test simply exercises its (implicit) constructor
+ * and confirms it is wired into the expected type hierarchy.
+ */
+public class ReportiumImportTestNgListenerTest {
+
+    @Test
+    public void testInstantiation() {
+        ReportiumImportTestNgListener listener = new ReportiumImportTestNgListener();
+
+        assertTrue(listener instanceof BaseReportiumTestNgListener);
+        assertTrue(listener instanceof IInvokedMethodListener);
+    }
+}

--- a/reportium-testng/src/test/java/com/perfecto/reportium/testng/ReportiumTestNgListenerTest.java
+++ b/reportium-testng/src/test/java/com/perfecto/reportium/testng/ReportiumTestNgListenerTest.java
@@ -1,0 +1,288 @@
+package com.perfecto.reportium.testng;
+
+import org.testng.IClass;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+import org.testng.internal.ConstructorOrMethod;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlTest;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link ReportiumTestNgListener}, in particular {@code getTags()} and
+ * {@code extractTagsFromAnnotations()}.
+ * <p>
+ * Note: {@code getTags()} extracts class-level tags via
+ * {@code testResult.getTestClass().getClass()} rather than {@code getRealClass()}. This means it
+ * actually reads annotations declared on the {@link IClass} *implementation* class, not on the
+ * class under test. This looks like a pre-existing bug/quirk in production code, but since we
+ * must not modify production code, these tests exercise the actual behavior: annotations placed
+ * directly on the fake {@link IClass} implementation used in the test.
+ */
+public class ReportiumTestNgListenerTest {
+
+    /**
+     * Holds fixture methods carrying real {@code @Test} annotations, purely so this test can grab
+     * a real {@link Method} with populated annotation elements via reflection. This class is never
+     * itself registered as a TestNG suite class (its name doesn't match the surefire test-class
+     * naming patterns), so TestNG never attempts to invoke these methods.
+     */
+    private static class MethodAnnotationFixtures {
+        @org.testng.annotations.Test(suiteName = "MySuite", testName = "MyTestName", description = "MyDescription",
+                groups = {"methodGroup1", "methodGroup2"})
+        public void annotatedFixtureMethod() {
+        }
+
+        @org.testng.annotations.Test
+        public void blankAnnotatedFixtureMethod() {
+        }
+    }
+
+    /** Fixture class carrying its own class-level @Test annotation, used for the getTags() scenario. */
+    @org.testng.annotations.Test(groups = {"classGroup"})
+    @Deprecated
+    private static class AnnotatedFakeIClass implements IClass {
+        @Override
+        public String getName() {
+            return "fake";
+        }
+
+        @Override
+        public XmlTest getXmlTest() {
+            return null;
+        }
+
+        @Override
+        public XmlClass getXmlClass() {
+            return null;
+        }
+
+        @Override
+        public String getTestName() {
+            return null;
+        }
+
+        @Override
+        public Class<?> getRealClass() {
+            return AnnotatedFakeIClass.class;
+        }
+
+        @Override
+        public Object[] getInstances(boolean create) {
+            return new Object[0];
+        }
+
+        @Override
+        public long[] getInstanceHashCodes() {
+            return new long[0];
+        }
+
+        @Override
+        public void addInstance(Object instance) {
+            // no-op
+        }
+    }
+
+    /** Same as above, but with no annotations at all on the implementation class. */
+    private static class PlainFakeIClass implements IClass {
+        @Override
+        public String getName() {
+            return "plain";
+        }
+
+        @Override
+        public XmlTest getXmlTest() {
+            return null;
+        }
+
+        @Override
+        public XmlClass getXmlClass() {
+            return null;
+        }
+
+        @Override
+        public String getTestName() {
+            return null;
+        }
+
+        @Override
+        public Class<?> getRealClass() {
+            return PlainFakeIClass.class;
+        }
+
+        @Override
+        public Object[] getInstances(boolean create) {
+            return new Object[0];
+        }
+
+        @Override
+        public long[] getInstanceHashCodes() {
+            return new long[0];
+        }
+
+        @Override
+        public void addInstance(Object instance) {
+            // no-op
+        }
+    }
+
+    private Method getFixtureMethod(String name) throws NoSuchMethodException {
+        return MethodAnnotationFixtures.class.getDeclaredMethod(name);
+    }
+
+    /**
+     * Builds a dynamic proxy implementing {@code org.testng.annotations.Test} that returns
+     * {@code null} for suiteName/testName/description and the given groups array. Real annotation
+     * instances can never return null for these elements (their defaults are empty strings), so a
+     * proxy is required to exercise the null-check branch in {@code addNonEmptyTag()}.
+     */
+    private org.testng.annotations.Test nullValuedTestAnnotationProxy(final String[] groups) {
+        InvocationHandler handler = new InvocationHandler() {
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) {
+                switch (method.getName()) {
+                    case "annotationType":
+                        return org.testng.annotations.Test.class;
+                    case "suiteName":
+                    case "testName":
+                    case "description":
+                        return null;
+                    case "groups":
+                        return groups;
+                    default:
+                        throw new UnsupportedOperationException("Unexpected call to " + method.getName());
+                }
+            }
+        };
+        return (org.testng.annotations.Test) Proxy.newProxyInstance(
+                getClass().getClassLoader(), new Class<?>[]{org.testng.annotations.Test.class}, handler);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // extractTagsFromAnnotations()
+    // ---------------------------------------------------------------------------------------
+
+    @org.testng.annotations.Test
+    public void testExtractTagsFromAnnotations_fullyPopulatedAnnotation() throws Exception {
+        ReportiumTestNgListener listener = new ReportiumTestNgListener();
+        Method fixture = getFixtureMethod("annotatedFixtureMethod");
+
+        List<String> tags = listener.extractTagsFromAnnotations(fixture.getAnnotations());
+
+        assertEquals(tags, Arrays.asList("MySuite", "MyTestName", "MyDescription", "methodGroup1", "methodGroup2"));
+    }
+
+    @org.testng.annotations.Test
+    public void testExtractTagsFromAnnotations_blankAnnotation_yieldsNoTags() throws Exception {
+        ReportiumTestNgListener listener = new ReportiumTestNgListener();
+        Method fixture = getFixtureMethod("blankAnnotatedFixtureMethod");
+
+        List<String> tags = listener.extractTagsFromAnnotations(fixture.getAnnotations());
+
+        assertTrue(tags.isEmpty());
+    }
+
+    @org.testng.annotations.Test
+    public void testExtractTagsFromAnnotations_emptyAnnotationsArray_yieldsNoTags() {
+        ReportiumTestNgListener listener = new ReportiumTestNgListener();
+
+        List<String> tags = listener.extractTagsFromAnnotations(new Annotation[0]);
+
+        assertTrue(tags.isEmpty());
+    }
+
+    @org.testng.annotations.Test
+    public void testExtractTagsFromAnnotations_nonTestAnnotation_isIgnored() {
+        ReportiumTestNgListener listener = new ReportiumTestNgListener();
+        // @Deprecated (RUNTIME retention) is present on this fixture class, but it is not @Test,
+        // so it should be filtered out by the annotationType().equals(Test.class) check.
+        List<String> tags = listener.extractTagsFromAnnotations(AnnotatedFakeIClass.class.getAnnotations());
+
+        // AnnotatedFakeIClass carries @Test(groups={"classGroup"}) and @Deprecated: only the
+        // @Test one should contribute a tag.
+        assertEquals(tags, Collections.singletonList("classGroup"));
+    }
+
+    @org.testng.annotations.Test
+    public void testExtractTagsFromAnnotations_nullValuesAndEmptyGroupElements_areSkipped() {
+        ReportiumTestNgListener listener = new ReportiumTestNgListener();
+
+        org.testng.annotations.Test proxyAnnotation =
+                nullValuedTestAnnotationProxy(new String[]{null, "", "g3"});
+
+        List<String> tags = listener.extractTagsFromAnnotations(new Annotation[]{proxyAnnotation});
+
+        assertEquals(tags, Collections.singletonList("g3"));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // getTags(ITestResult)
+    // ---------------------------------------------------------------------------------------
+
+    @org.testng.annotations.Test
+    public void testGetTags_classAndMethodAnnotations_combined() throws Exception {
+        ReportiumTestNgListener listener = new ReportiumTestNgListener();
+
+        IClass fakeIClass = new AnnotatedFakeIClass();
+
+        Method fixtureMethod = getFixtureMethod("annotatedFixtureMethod");
+        ConstructorOrMethod constructorOrMethod = new ConstructorOrMethod(fixtureMethod);
+
+        ITestNGMethod testngMethod = createMock(ITestNGMethod.class);
+        expect(testngMethod.getConstructorOrMethod()).andReturn(constructorOrMethod);
+        replay(testngMethod);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getTestClass()).andReturn(fakeIClass);
+        expect(testResult.getMethod()).andReturn(testngMethod);
+        replay(testResult);
+
+        String[] tags = listener.getTags(testResult);
+
+        assertEquals(tags,
+                new String[]{"classGroup", "MySuite", "MyTestName", "MyDescription", "methodGroup1", "methodGroup2"});
+
+        verify(testResult, testngMethod);
+    }
+
+    @org.testng.annotations.Test
+    public void testGetTags_noClassAnnotationsAndNoMethod_yieldsEmptyArray() throws Exception {
+        ReportiumTestNgListener listener = new ReportiumTestNgListener();
+
+        IClass fakeIClass = new PlainFakeIClass();
+
+        // A ConstructorOrMethod built from a Constructor makes getMethod() return null,
+        // exercising the "method != null" false branch in getTags().
+        ConstructorOrMethod constructorOrMethod =
+                new ConstructorOrMethod(PlainFakeIClass.class.getDeclaredConstructor());
+
+        ITestNGMethod testngMethod = createMock(ITestNGMethod.class);
+        expect(testngMethod.getConstructorOrMethod()).andReturn(constructorOrMethod);
+        replay(testngMethod);
+
+        ITestResult testResult = createMock(ITestResult.class);
+        expect(testResult.getTestClass()).andReturn(fakeIClass);
+        expect(testResult.getMethod()).andReturn(testngMethod);
+        replay(testResult);
+
+        String[] tags = listener.getTags(testResult);
+
+        assertEquals(tags, new String[0]);
+
+        verify(testResult, testngMethod);
+    }
+}


### PR DESCRIPTION
## Summary
- Wires the JaCoCo Maven plugin into the parent POM (feeds the previously-unused `surefireArgLine` property that `maven-surefire-plugin` already consumed).
- Adds unit tests for the lowest-coverage classes in each module, following each module's existing TestNG + EasyMock + Hamcrest conventions. `reportium-import-selenium` had no test suite at all before this change (test-scope deps added to its `pom.xml`, plus new tests).
- No production code changes — test files and POM/build wiring only.

## Coverage delta (repo-wide, instruction / line / branch)
| Module | Before | After |
|---|---|---|
| reportium-java | 66.0% / 65.4% / 62.0% | 92.7% / 94.1% / 81.8% |
| reportium-import-java | 60.3% / 63.8% / 44.5% | 88.7% / 87.8% / 81.7% |
| reportium-testng | 0% / 0% / 0% | 100% / 100% / 100% |
| reportium-import-selenium | no tests | 96.6% / 98.0% / 94.7% |
| **Total** | **59.8% / 61.6% / 48.6%** | **91.0% / 91.2% / 83.3%** |

Raw branch coverage (83.3%) is pulled down by `Objects.equals`/`hashCode` branches on a handful of pure-DTO classes (`Job`, `Project`, `CustomField`, `MobileInfo`, `BrowserInfo`) that were deliberately left untested — testing generated equals/hashCode is coverage theatre, not real signal. Excluding those, in-scope branch coverage is 94.9% (reportium-java) and 91.6% (reportium-import-java).

## Validation
- `mvn test` — full reactor build green (all modules).

## Notes for reviewer
- No production code changed; only test files and build config (JaCoCo wiring, missing test-scope deps).
- A couple of documented, genuinely-unreachable defensive branches (e.g. a null-guard in `PerfectoReportiumClient` that every call site already prevents) were left uncovered rather than reflection-hacked into existence.